### PR TITLE
[ci:component:github.com/gardener/external-dns-management:v0.7.5->v0.7.6]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "v0.7.5"
+  tag: "v0.7.6"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/external-dns-management $42eb43d93c7f12057f29d593a1b0ef5dbce32a29
fix for shutdown on lease lost
```