### PR TITLE
[ci:component:github.com/gardener/external-dns-management:v0.7.6->v0.7.7]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "v0.7.6"
+  tag: "v0.7.7"


### PR DESCRIPTION
*Release Notes*:
``` noteworthy user github.com/gardener/external-dns-management $a70d91d4ec4cf7ec7439216ec360733bc31ffc49
Cloudflare DNS is now supported as a DNS provider.
```

``` improvement developer github.com/gardener/external-dns-management $cd43ccaaf2efadf127d36f3140d741bb0a63c9a3
The package `raw` now provides support for DNS APIs supporting only single record updates.
The *AliCloud* provider has been adapted accordingly and can be used as an example for implementing such providers.
```