### PR TITLE
Upgrade github.com/gardener/external-dns-management

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "v0.7.7"
+  tag: "v0.7.10"


### PR DESCRIPTION
*Release Notes*:
``` improvement user github.com/gardener/external-dns-management #73 @MartinWeindel
alicloud: avoid provider update race if get zones fails
```

``` improvement user github.com/gardener/external-dns-management #72 @MartinWeindel
Added AWS alias targets for regions `us-gov-west-1` AWS GovCloud (US) and `me-south-1` Middle East (Bahrain)
```

``` improvement operator github.com/gardener/external-dns-management #69 @MartinWeindel
improve error handling on retrieving cluster server version
```

``` improvement user github.com/gardener/external-dns-management #63 @MartinWeindel
avoid azure provider update race if credentials are invalid
```

``` improvement operator github.com/gardener/external-dns-management #76 @MartinWeindel
own rate limiter for failed provider reconcilation
```

``` improvement operator github.com/gardener/external-dns-management #74 @MartinWeindel
Fix stale entries on provider spec changes or errors
```

``` improvement operator github.com/gardener/external-dns-management #77 @jia-jerry
Add rate limiter to for Alicloud DNS
```
