### PR TITLE
Upgrade github.com/gardener/external-dns-management

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,4 +2,4 @@ images:
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: eu.gcr.io/gardener-project/dns-controller-manager
-  tag: "v0.7.10"
+  tag: "v0.7.11"


### PR DESCRIPTION
*Release Notes*:
``` improvement user github.com/gardener/external-dns-management #83 @MartinWeindel
fix creating DNS entry with wildcard on base domain of hosted zone for openstack-designate.
```