### PR TITLE
fixing panic on deleting multiple DNS entries from state

### DIFF
--- a/pkg/controller/common/state.go
+++ b/pkg/controller/common/state.go
@@ -143,14 +143,15 @@ func (s *StateHandler) EnsureEntries(entries []dnsapi.DNSEntry) bool {
 	mod := false
 	names := sets.String{}
 	for _, entry := range entries {
-		mod = s.EnsureEntryFor(&entry)
+		mod = s.EnsureEntryFor(&entry) || mod
 		names.Insert(entry.Name)
 	}
 	if len(entries) != len(s.state.Entries) {
-		for i, e := range s.state.Entries {
+		for i := len(s.state.Entries) - 1; i >= 0; i-- {
+			e := s.state.Entries[i]
 			if !names.Has(e.Name) {
-				mod = true
 				s.state.Entries = append(s.state.Entries[:i], s.state.Entries[i+1:]...)
+				mod = true
 			}
 		}
 	}

--- a/pkg/controller/common/state_test.go
+++ b/pkg/controller/common/state_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package common
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	api "github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis"
+)
+
+var _ = Describe("StateHandler", func() {
+	DescribeTable("#EnsureEntries",
+		func(expectedMod bool, newEntryNames ...string) {
+			handler := &StateHandler{state: &api.DNSState{}}
+			handler.state.Entries = []*api.DNSEntry{
+				{Name: "entry1", Spec: &v1alpha1.DNSEntrySpec{}},
+				{Name: "entry2", Spec: &v1alpha1.DNSEntrySpec{}},
+			}
+			var newEntries []v1alpha1.DNSEntry
+			for _, name := range newEntryNames {
+				newEntries = append(newEntries, v1alpha1.DNSEntry{ObjectMeta: metav1.ObjectMeta{Name: name}})
+			}
+			mod := handler.EnsureEntries(newEntries)
+			Expect(mod).To(Equal(expectedMod))
+			Expect(len(handler.state.Entries)).To(Equal(len(newEntries)))
+		},
+		Entry("unchanged", false, "entry1", "entry2"),
+		Entry("unchanged2", false, "entry2", "entry1"),
+		Entry("add/remove", true, "entry1", "entry3"),
+		Entry("delete one", true, "entry1"),
+		Entry("replace all", true, "entry3", "entry4"),
+		Entry("none", true),
+	)
+})

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,110 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeNone)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	global.Suite.PushContainerNode(
+		description,
+		func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		},
+		flag,
+		codelocation.New(2),
+	)
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,129 @@
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description  interface{}
+	Parameters   []interface{}
+	Pending      bool
+	Focused      bool
+	codeLocation types.CodeLocation
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	var description string
+	descriptionValue := reflect.ValueOf(t.Description)
+	switch descriptionValue.Kind() {
+	case reflect.String:
+		description = descriptionValue.String()
+	case reflect.Func:
+		values := castParameters(descriptionValue, t.Parameters)
+		res := descriptionValue.Call(values)
+		if len(res) != 1 {
+			panic(fmt.Sprintf("The describe function should return only a value, returned %d", len(res)))
+		}
+		if res[0].Kind() != reflect.String {
+			panic(fmt.Sprintf("The describe function should return a string, returned %#v", res[0]))
+		}
+		description = res[0].String()
+	default:
+		panic(fmt.Sprintf("Description can either be a string or a function, got %#v", descriptionValue))
+	}
+
+	if t.Pending {
+		global.Suite.PushItNode(description, func() {}, types.FlagTypePending, t.codeLocation, 0)
+		return
+	}
+
+	values := castParameters(itBody, t.Parameters)
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		global.Suite.PushItNode(description, body, types.FlagTypeFocused, t.codeLocation, global.DefaultTimeout)
+	} else {
+		global.Suite.PushItNode(description, body, types.FlagTypeNone, t.codeLocation, global.DefaultTimeout)
+	}
+}
+
+func castParameters(function reflect.Value, parameters []interface{}) []reflect.Value {
+	res := make([]reflect.Value, len(parameters))
+	funcType := function.Type()
+	for i, param := range parameters {
+		if param == nil {
+			inType := funcType.In(i)
+			res[i] = reflect.Zero(inType)
+		} else {
+			res[i] = reflect.ValueOf(param)
+		}
+	}
+	return res
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      true,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -300,6 +300,7 @@ github.com/nxadm/tail/winfile
 ## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/ginkgo
 github.com/onsi/ginkgo/ginkgo/convert
 github.com/onsi/ginkgo/ginkgo/interrupthandler


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
Fix and regression test for panic on deleting multiple entries in extension state

**Which issue(s) this PR fixes**:
Fixes #21 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fixing panic on deleting multiple DNS entries from state
```
