### PR TITLE
Keep objects of shoot managed resources during migration

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -198,6 +198,11 @@ func (a *actuator) Restore(ctx context.Context, ex *extensionsv1alpha1.Extension
 
 // Migrate the Extension resource.
 func (a *actuator) Migrate(ctx context.Context, ex *extensionsv1alpha1.Extension) error {
+	// Keep objects for shoot managed resources so that they are not deleted from the shoot during the migration
+	if err := managedresources.KeepManagedResourceObjects(ctx, a.Client(), ex.GetNamespace(), ShootResourcesName, true); err != nil {
+		return err
+	}
+
 	return a.Delete(ctx, ex)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
Keep objects of shoot managed resources during migration:

* Set `keepObjects` to true for shoot managed resources during migration before deleting them, so that the actual shoot objects are not deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
All extensions should take care about their managed resources during the migration. Unless there is a special reason not to do so, all managed resources should be deleted after setting `keepObjects` to true, so that the actual shoot objects are not deleted.

**Release note**:

```improvement operator
NONE
```