### PR TITLE
Increase minAllowed

### DIFF
--- a/charts/internal/shoot-dns-service-seed/values.yaml
+++ b/charts/internal/shoot-dns-service-seed/values.yaml
@@ -26,7 +26,7 @@ resources:
 vpa:
   enabled: true
   minAllowed:
-    cpu: 5m
-    memory: 25Mi
+    cpu: 25m
+    memory: 50Mi
   updatePolicy:
     updateMode: "Auto"


### PR DESCRIPTION
**How to categorize this PR?**

/area auto-scaling
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The current minAllowed values are too low to cope with a restart of the shoot-dns-service.
This caused failing shoot-dns-service pods after the vpa scaled them down.

**Special notes for your reviewer**:
As the pod runs in the shoot controlplane this change affects a lot of pods and therefore could lead to significantly more costs. Better would be if this were handled by the vpa recommender and we hopefully can revert this change once the recommender handles this situation. Issue https://github.com/gardener/autoscaler/pull/69

```other operator
NONE 
```
