### PR TITLE
add controlplane role to shoot-dns-service controller

### DIFF
--- a/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
       labels:
         app: {{ template "service.name" . }}
         release: {{ .Release.Name }}
+        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/to-seed-apiserver: allowed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane robustness high-availability
/kind bug
/priority normal

**What this PR does / why we need it**:
shoot-dns-service controller has to be labelled as controlplane to be restarted by DependencyWatchDog if kube-apiserver recovers

Which issue(s) this PR fixes:
#36 
see also https://github.com/gardener/gardener/issues/3679

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
