### PR TITLE
longer timeouts for service of type LB

### DIFF
--- a/test/system/shootdns_test.go
+++ b/test/system/shootdns_test.go
@@ -179,13 +179,13 @@ var _ = Describe("ShootDNS test", func() {
 	BeforeEach(f.prepareClientsAndCluster, 60)
 
 	framework.CIt("Create and delete echoheaders service with type LoadBalancer", func(ctx context.Context) {
-		f.createEchoheaders(ctx, true, true, 120*time.Second, 420*time.Second)
-	}, 600*time.Second)
+		f.createEchoheaders(ctx, true, true, 360*time.Second, 420*time.Second)
+	}, 840*time.Second)
 
 	framework.CIt("Create echoheaders ingress", func(ctx context.Context) {
 		// cleanup during shoot deletion to test proper cleanup
-		f.createEchoheaders(ctx, false, false, 120*time.Second, 420*time.Second)
-	}, 600*time.Second)
+		f.createEchoheaders(ctx, false, false, 180*time.Second, 420*time.Second)
+	}, 660*time.Second)
 
 	framework.CIt("Create custom DNS entry", func(ctx context.Context) {
 		namespace := "shootdns-test-custom-dnsentry"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
Creation of service of type LB takes quite long on some infrastructures and DNS lookup depends on external IP address.
Therefore the timeout have been set higher.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
