### PR TITLE
avoid conflicting updates of the `status.state` of the extension resource by the replication controller

### DIFF
--- a/pkg/controller/common/env.go
+++ b/pkg/controller/common/env.go
@@ -18,11 +18,8 @@ package common
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/config"
-	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/service"
-
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +32,7 @@ type Env struct {
 	restConfig *rest.Config
 	client     client.Client
 	config     config.DNSServiceConfig
+	apiReader  client.Reader
 	logr.Logger
 }
 
@@ -44,10 +42,6 @@ func NewEnv(name string, config config.DNSServiceConfig) *Env {
 		config: config,
 		Logger: log.Log.WithName(name),
 	}
-}
-
-func (e *Env) Infof(msg string, args ...interface{}) {
-	e.Info(fmt.Sprintf(msg, args...), "component", service.ServiceName)
 }
 
 func (e *Env) RestConfig() *rest.Config {
@@ -60,6 +54,10 @@ func (e *Env) Client() client.Client {
 
 func (e *Env) Config() *config.DNSServiceConfig {
 	return &e.config
+}
+
+func (e *Env) APIReader() client.Reader {
+	return e.apiReader
 }
 
 func (e *Env) CreateObject(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
@@ -88,6 +86,12 @@ func (e *Env) InjectLogger(l logr.Logger) error {
 // InjectConfig injects the rest configuration into the reconciler.
 func (e *Env) InjectConfig(config *rest.Config) error {
 	e.restConfig = config
+	return nil
+}
+
+// InjectAPIReader injects the APIReader into the reconciler.
+func (e *Env) InjectAPIReader(reader client.Reader) error {
+	e.apiReader = reader
 	return nil
 }
 

--- a/pkg/controller/common/state.go
+++ b/pkg/controller/common/state.go
@@ -184,9 +184,9 @@ func (s *StateHandler) EnsureEntryFor(entry *dnsapi.DNSEntry) bool {
 	return true
 }
 
-func (s *StateHandler) Update() error {
+func (s *StateHandler) Update(reason string) error {
 	if s.modified {
-		s.Infof("updating modified state for %s", s.ext.Name)
+		s.Info("updating modified state", "namespace", s.ext.Namespace, "extension", s.ext.Name, "reason", reason)
 		wire := &wireapi.DNSState{}
 		wire.APIVersion = wireapi.SchemeGroupVersion.String()
 		wire.Kind = wireapi.DNSStateKind
@@ -200,13 +200,13 @@ func (s *StateHandler) Update() error {
 		}
 		s.ext.Status.State.Raw, err = json.Marshal(wire)
 		if err != nil {
-			s.Infof("marshalling failed: %s", err)
+			s.Info("marshalling failed", "error", err)
 			return err
 		}
 		s.ext.Status.State.Object = nil
 		err = s.client.Status().Update(s.ctx, s.ext)
 		if err != nil {
-			s.Infof("update failed: %s", err)
+			s.Info("update failed", "error", err)
 		} else {
 			s.modified = false
 		}

--- a/pkg/controller/common/utils.go
+++ b/pkg/controller/common/utils.go
@@ -48,9 +48,9 @@ func CopyMap(m map[string]string) map[string]string {
 	return r
 }
 
-func FindExtension(ctx context.Context, c client.Client, namespace string) (*extapi.Extension, error) {
+func FindExtension(ctx context.Context, reader client.Reader, namespace string) (*extapi.Extension, error) {
 	list := &extapi.ExtensionList{}
-	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+	if err := reader.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -229,7 +229,7 @@ func (a *actuator) createOrUpdateSeedResources(ctx context.Context, cluster *con
 	if err != nil {
 		return err
 	}
-	err = handler.Update()
+	err = handler.Update("refresh")
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/replication/replication_suite_test.go
+++ b/pkg/controller/replication/replication_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package replication_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestControlplane(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Replication Controller Suite")
+}

--- a/pkg/controller/replication/stringslock.go
+++ b/pkg/controller/replication/stringslock.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package replication
+
+import (
+	"sync"
+)
+
+// StringsLock provides separate lock per given name with TryLock/Unlock semantics.
+type StringsLock struct {
+	lock    sync.Mutex
+	strings map[string]struct{}
+}
+
+// NewStringsLock creates a new StringsLock object
+func NewStringsLock() *StringsLock {
+	return &StringsLock{strings: map[string]struct{}{}}
+}
+
+// TryLock returns true if the name is successfully locked, i.e. not locked by another consumer.
+// If true is returned, it must be unlocked with `Unlock`
+func (this *StringsLock) TryLock(name string) bool {
+	this.lock.Lock()
+	defer this.lock.Unlock()
+
+	_, ok := this.strings[name]
+	if !ok {
+		this.strings[name] = struct{}{}
+	}
+	return !ok
+}
+
+// Unlock unlocks a name locked with `TryLock`
+func (this *StringsLock) Unlock(name string) {
+	this.lock.Lock()
+	defer this.lock.Unlock()
+
+	_, ok := this.strings[name]
+	if !ok {
+		panic("missing lock")
+	}
+	delete(this.strings, name)
+}

--- a/pkg/controller/replication/stringslock_test.go
+++ b/pkg/controller/replication/stringslock_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package replication
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StringsLock", func() {
+	It("should trylock and unlock correctly", func() {
+		lock := NewStringsLock()
+		Expect(lock.TryLock("foo")).To(BeTrue())
+		Expect(lock.TryLock("bar")).To(BeTrue())
+		Expect(lock.TryLock("foo")).To(BeFalse())
+		lock.Unlock("foo")
+		lock.Unlock("bar")
+		Expect(lock.TryLock("foo")).To(BeTrue())
+		Expect(lock.TryLock("foo")).To(BeFalse())
+		lock.Unlock("foo")
+		Expect(len(lock.strings)).To(Equal(0))
+	})
+
+	It("should trylock and unlock concurrently without deadlock", func() {
+		f := func(lock *StringsLock, idx int) {
+			name := fmt.Sprintf("name%d", idx)
+			for j := 0; j < 1000; j++ {
+				for !lock.TryLock(name) {
+					time.Sleep(1 * time.Microsecond)
+				}
+				time.Sleep(5 * time.Microsecond)
+				lock.Unlock(name)
+			}
+		}
+		testConcurrently(20, f)
+	})
+})
+
+func testConcurrently(threadCount int, f func(lock *StringsLock, idx int)) {
+	lock := NewStringsLock()
+	wg := sync.WaitGroup{}
+	wg.Add(threadCount)
+	for i := 0; i < threadCount; i++ {
+		go func(k int) {
+			f(lock, k%3)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	Expect(len(lock.strings)).To(Equal(0))
+}


### PR DESCRIPTION
in parallel

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The shoot-dns-service can loose its leader election if there is a high workload because of conflicting updates on replicating changed DNS entries into the DNS state of the extension object.
The replication controller, responsible for replication the entries into the `status.state` of the extension resource, now locks the namespace to avoid conflicting updates. If the namespace is already locked, the reconciliation is delay for about 1-2s.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
avoid conflicting updates of the `status.state` of the extension resource by the replication controller
```
