### PR TITLE
Remove the "garden.sapcloud.io/role" label from control plane components

### DIFF
--- a/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
@@ -24,7 +24,6 @@ spec:
       labels:
         app: {{ template "service.name" . }}
         release: {{ .Release.Name }}
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed


### PR DESCRIPTION
/kind cleanup

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/422

Ref gardener/gardener#1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
