### PR TITLE
Remote provider for default domain: use label instead of an annotation to activate feature per seed

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	apisservice "github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/service"
@@ -94,8 +93,8 @@ const (
 	ShootDNSServiceMaintainerAnnotation = "service.dns.extensions.gardener.cloud/maintainer"
 	// ExternalDNSProviderName is the name of the external DNS provider
 	ExternalDNSProviderName = "external"
-	// ShootDNSServiceUseRemoteDefaultDomainAnnotation is the annotation key for marking a seed to use the remote DNS-provider for the default domain
-	ShootDNSServiceUseRemoteDefaultDomainAnnotation = "service.dns.extensions.gardener.cloud/use-remote-default-domain"
+	// ShootDNSServiceUseRemoteDefaultDomainLabel is the label key for marking a seed to use the remote DNS-provider for the default domain
+	ShootDNSServiceUseRemoteDefaultDomainLabel = "service.dns.extensions.gardener.cloud/use-remote-default-domain"
 )
 
 // dnsAnnotationCRD contains the contents of the dnsAnnotationCRD.yaml file.
@@ -629,10 +628,9 @@ func (a *actuator) prepareDefaultExternalDNSProvider(ctx context.Context, dnscon
 }
 
 func (a *actuator) useRemoteDefaultDomain(cluster *controller.Cluster) bool {
-	if a.Config().RemoteDefaultDomainSecret != nil && cluster.Seed.Annotations != nil {
-		annot, ok := cluster.Seed.Annotations[ShootDNSServiceUseRemoteDefaultDomainAnnotation]
-		b, err := strconv.ParseBool(annot)
-		return ok && err == nil && b
+	if a.Config().RemoteDefaultDomainSecret != nil && cluster.Seed.Labels != nil {
+		annot, ok := cluster.Seed.Labels[ShootDNSServiceUseRemoteDefaultDomainLabel]
+		return ok && annot == "true"
 	}
 	return false
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
The support of remote provider for the default external DNSProvider was introduced with PR #104.
The feature is activated per seed. For easier landscape management the feature is now activated by a label instead of an annotation:

```yaml
kind: Seed
metadata:
  labels:
    service.dns.extensions.gardener.cloud/use-remote-default-domain: "true"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
