### PR TITLE
Add admission image to pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -12,6 +12,11 @@ gardener-extension-shoot-dns-service:
             image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-dns-service'
             dockerfile: 'Dockerfile'
             target: gardener-extension-shoot-dns-service
+          gardener-extension-admission-shoot-dns-service:
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/extensions/admission-shoot-dns-service'
+            dockerfile: 'Dockerfile'
+            target: gardener-extension-admission-shoot-dns-service
   jobs:
     head-update:
       traits:
@@ -43,4 +48,6 @@ gardener-extension-shoot-dns-service:
         publish:
           dockerimages:
             gardener-extension-shoot-dns-service:
+              tag_as_latest: true
+            gardener-extension-admission-shoot-dns-service:
               tag_as_latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-shoot-dns-service /gardener-extension-shoot-dns-service
 ENTRYPOINT ["/gardener-extension-shoot-dns-service"]
 
-############# gardener-extension-admission-aws
+############# gardener-extension-admission-shoot-dns-service
 FROM base AS gardener-extension-admission-shoot-dns-service
 
 COPY --from=builder /go/bin/gardener-extension-admission-shoot-dns-service /gardener-extension-admission-shoot-dns-service


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
The ci pipeline definition is missing the publish spec for the additional admission image introduced with #101

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add admission image to ci pipeline
```
