### PR TITLE
Don't mutate shoots in deletion

### DIFF
--- a/pkg/admission/mutator/mutator_test.go
+++ b/pkg/admission/mutator/mutator_test.go
@@ -16,6 +16,7 @@ package mutator_test
 
 import (
 	"context"
+	"time"
 
 	admissionmutator "github.com/gardener/gardener-extension-shoot-dns-service/pkg/admission/mutator"
 	serviceinstall "github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/service/install"
@@ -109,6 +110,14 @@ var _ = Describe("Shoot Mutator", func() {
 						},
 						Disabled: &bfalse,
 					},
+				},
+			},
+		}
+		shootInDeletion = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}},
+			Spec: gardencorev1beta1.ShootSpec{
+				DNS: &gardencorev1beta1.DNS{
+					Domain: &domain,
 				},
 			},
 		}
@@ -231,6 +240,7 @@ var _ = Describe("Shoot Mutator", func() {
 		Entry("disabled sync", dnsStyleEnabled, shootWithDisabledSync, []gardencorev1beta1.DNSProvider{additional}, BeNil(), modifyCopy(dnsConfig, func(cfg *servicev1alpha1.DNSConfig) {
 			cfg.SyncProvidersFromShootSpecDNS = &bfalse
 		}), nil),
+		Entry("shoot in deletion", dnsStyleEnabled, shootInDeletion, []gardencorev1beta1.DNSProvider{additional}, BeNil(), nil, nil),
 	)
 })
 

--- a/pkg/admission/mutator/shoot_mutator.go
+++ b/pkg/admission/mutator/shoot_mutator.go
@@ -132,6 +132,10 @@ func (s *shoot) isDisabled(shoot *gardencorev1beta1.Shoot) bool {
 	if shoot.Spec.DNS == nil {
 		return true
 	}
+	if shoot.DeletionTimestamp != nil {
+		// don't mutate shoots in deletion
+		return true
+	}
 	ext := s.findExtension(shoot)
 	if ext == nil {
 		return false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If a shoot object is in deletion, the mutation of the extension provider config fails with "field immutable". Therefore the mutator is disabled in this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The mutator webhook must not mutate shoot objects in deletion.
```
