### PR TITLE
Copy zone for external DNSEntry from external DNSRecord

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -614,17 +614,23 @@ func (a *actuator) prepareDefaultExternalDNSProvider(ctx context.Context, dnscon
 		}, nil
 	}
 
-	secretRef, providerType, err := GetSecretRefFromDNSRecordExternal(ctx, a.Client(), namespace, cluster.Shoot.Name)
+	secretRef, providerType, zone, err := GetSecretRefFromDNSRecordExternal(ctx, a.Client(), namespace, cluster.Shoot.Name)
 	if err != nil || secretRef == nil {
 		return nil, err
 	}
-	return &apisservice.DNSProvider{
+	provider := &apisservice.DNSProvider{
 		Domains: &apisservice.DNSIncludeExclude{
 			Include: []string{*cluster.Shoot.Spec.DNS.Domain},
 		},
 		SecretName: &secretRef.Name,
 		Type:       &providerType,
-	}, nil
+	}
+	if zone != nil {
+		provider.Zones = &apisservice.DNSIncludeExclude{
+			Include: []string{*zone},
+		}
+	}
+	return provider, nil
 }
 
 func (a *actuator) useRemoteDefaultDomain(cluster *controller.Cluster) bool {

--- a/pkg/controller/lifecycle/dnsrecord.go
+++ b/pkg/controller/lifecycle/dnsrecord.go
@@ -29,11 +29,11 @@ import (
 
 // GetSecretRefFromDNSRecordExternal reads the secret reference and type from the DNSRecord external
 // If the DNSRecord resource is not found, it returns nil.
-func GetSecretRefFromDNSRecordExternal(ctx context.Context, c client.Client, namespace, shootName string) (*corev1.SecretReference, string, error) {
+func GetSecretRefFromDNSRecordExternal(ctx context.Context, c client.Client, namespace, shootName string) (*corev1.SecretReference, string, *string, error) {
 	dns := &extensionsv1alpha1.DNSRecord{}
 	if err := c.Get(ctx, kutil.Key(namespace, shootName+"-external"), dns); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
-	return &dns.Spec.SecretRef, dns.Spec.Type, nil
+	return &dns.Spec.SecretRef, dns.Spec.Type, dns.Spec.Zone, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
If there are multiple zones matching the base domain of the `external` `DNSProvider`, the zone must copied from the external `DNSRecord` for  disambiguation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Copy zone for external DNSEntry from external DNSRecord
```
