### PR TITLE
Fix mutating webhook for shoots using apiVersion v1alpha1

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The mutating admission webhook denies creating shoots with apiVersion v1alpha1:
```
admission webhook "mutation.service.dns.extensions.gardener.cloud" denied the request: unexpected request kind core.gardener.cloud/v1alpha1, Kind=Shoot
```
The mutating webhook configuration is adjusted to fix the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Adjust mutating webhook configuration to work with shoot apiVersion `core.gardener.cloud/v1alpha1` too
```
