### PR TITLE
Minor fixes related to `DNSProvider` management with primary provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.17.6 AS builder
+FROM golang:1.17.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-dns-service
 COPY . .
 RUN make install
 
 ############# base
-FROM alpine:3.15.0 AS base
+FROM alpine:3.15.3 AS base
 
 ############# gardener-extension-shoot-dns-service
 FROM base AS gardener-extension-shoot-dns-service

--- a/example/50-mutatingwebhookconfiguration.yaml
+++ b/example/50-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE

--- a/pkg/admission/mutator/mutator_test.go
+++ b/pkg/admission/mutator/mutator_test.go
@@ -128,7 +128,12 @@ var _ = Describe("Shoot Mutator", func() {
 			},
 			SyncProvidersFromShootSpecDNS: &btrue,
 		}
-		awsType = "aws-route53"
+		awsType        = "aws-route53"
+		primaryDefault = gardencorev1beta1.DNSProvider{
+			Type:       &awsType,
+			SecretName: &secretName1,
+			Primary:    &btrue,
+		}
 		primary = gardencorev1beta1.DNSProvider{
 			Domains:    &gardencorev1beta1.DNSIncludeExclude{Include: []string{"my.domain.test"}, Exclude: []string{"private.my.domain.test"}},
 			Type:       &awsType,
@@ -204,6 +209,18 @@ var _ = Describe("Shoot Mutator", func() {
 		Entry("extension enabled - default domain", dnsStyleEnabled, shoot, nil, BeNil(), modifyCopy(dnsConfig, func(cfg *servicev1alpha1.DNSConfig) {
 			cfg.SyncProvidersFromShootSpecDNS = &btrue
 		}), nil),
+		Entry("primaryDefault", dnsStyleEnabled, shoot, []gardencorev1beta1.DNSProvider{primaryDefault}, BeNil(), modifyCopy(dnsConfig, func(cfg *servicev1alpha1.DNSConfig) {
+			cfg.SyncProvidersFromShootSpecDNS = &btrue
+			cfg.Providers = []servicev1alpha1.DNSProvider{
+				{
+					Domains: &servicev1alpha1.DNSIncludeExclude{
+						Include: []string{domain},
+					},
+					SecretName: &secretMappedName1,
+					Type:       &awsType,
+				},
+			}
+		}), []gardencorev1beta1.NamedResourceReference{primaryResource}),
 		Entry("primary", dnsStyleEnabled, shoot, []gardencorev1beta1.DNSProvider{primary}, BeNil(), modifyCopy(dnsConfig, func(cfg *servicev1alpha1.DNSConfig) {
 			cfg.SyncProvidersFromShootSpecDNS = &btrue
 			cfg.Providers = []servicev1alpha1.DNSProvider{

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -487,6 +487,22 @@ func (a *actuator) addCleanupOfOldAdditionalProviders(dnsProviders map[string]co
 		}
 	}
 
+	if dw, ok := dnsProviders[ExternalDNSProviderName]; dw == nil && ok {
+		// delete non-migrated non-default external DNS provider if it exists
+		provider := &dnsv1alpha1.DNSProvider{}
+		if err := a.Client().Get(
+			ctx,
+			kutil.Key(namespace, ExternalDNSProviderName),
+			provider,
+		); err == nil {
+			dnsProviders[provider.Name] = component.OpDestroy(NewProviderDeployWaiter(
+				a.deprecatedLogger,
+				a.Client(),
+				provider,
+			))
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If a primary provider is specified in the shoot spec, the migration of the `DNSProvider` management to the shoot-dns-service extension is incomplete. The domain include is missing as specified at `spec.dns.domain` and the old `external` `DNSProvider` is not deleted.

Besides some minor improvements have been included in this PR:
- mutatorwebhook is only active if shoot is reconciling and in state processing 
- update of golang to version `1.17.8`
- update of alpine to version `3.15.3`
- remove `v1alpha1` from file `example/50-mutatingwebhookconfiguration.yaml`(minor leftover from  #115)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add domain include for primary provider if no domain and zones includes are specified and delete obsolete `external` `DNSProvider` resource. 
```
