### PR TITLE
Remove obsolete resource refs

### DIFF
--- a/pkg/admission/mutator/mutator_test.go
+++ b/pkg/admission/mutator/mutator_test.go
@@ -86,10 +86,34 @@ var _ = Describe("Shoot Mutator", func() {
 				},
 				Resources: []gardencorev1beta1.NamedResourceReference{
 					{
+						Name: "shoot-dns-service-my-secret-obsolete1",
+						ResourceRef: v1.CrossVersionObjectReference{
+							Kind:       "Secret",
+							Name:       "foo",
+							APIVersion: "v1",
+						},
+					},
+					{
 						Name: secretMappedName2,
 						ResourceRef: v1.CrossVersionObjectReference{
 							Kind:       "Secret",
 							Name:       "foo",
+							APIVersion: "v1",
+						},
+					},
+					{
+						Name: "shoot-dns-service-my-secret-obsolete2",
+						ResourceRef: v1.CrossVersionObjectReference{
+							Kind:       "Secret",
+							Name:       "foo",
+							APIVersion: "v1",
+						},
+					},
+					{
+						Name: "other",
+						ResourceRef: v1.CrossVersionObjectReference{
+							Kind:       "Secret",
+							Name:       "other",
 							APIVersion: "v1",
 						},
 					},
@@ -139,6 +163,14 @@ var _ = Describe("Shoot Mutator", func() {
 			ResourceRef: v1.CrossVersionObjectReference{
 				Kind:       "Secret",
 				Name:       secretName1,
+				APIVersion: "v1",
+			},
+		}
+		otherResource = gardencorev1beta1.NamedResourceReference{
+			Name: "other",
+			ResourceRef: v1.CrossVersionObjectReference{
+				Kind:       "Secret",
+				Name:       "other",
 				APIVersion: "v1",
 			},
 		}
@@ -235,7 +267,7 @@ var _ = Describe("Shoot Mutator", func() {
 					},
 				},
 			}
-		}), []gardencorev1beta1.NamedResourceReference{additionalResource, primaryResource}),
+		}), []gardencorev1beta1.NamedResourceReference{additionalResource, otherResource, primaryResource}),
 		Entry("disabled sync", dnsStyleEnabled, shootWithDisabledSync, []gardencorev1beta1.DNSProvider{additional}, BeNil(), modifyCopy(dnsConfig, func(cfg *servicev1alpha1.DNSConfig) {
 			cfg.SyncProvidersFromShootSpecDNS = &bfalse
 		}), nil),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Remove obsolete resource reference if a provider is removed.

**Which issue(s) this PR fixes**:
Fixes #120

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Remove obsolete resource reference if a provider is removed.
```
