### PR TITLE
Fix integration test TestDefinition

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -12,9 +12,9 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/system
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       -seed-kubecfg=$TM_KUBECONFIG_PATH/seed.config
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.17.9

--- a/test/system/shootdns_test.go
+++ b/test/system/shootdns_test.go
@@ -175,7 +175,7 @@ var _ = Describe("ShootDNS test", func() {
 		ResourceDir: "../resources",
 	})
 
-	BeforeEach(f.prepareClientsAndCluster, 60)
+	BeforeEach(f.prepareClientsAndCluster)
 
 	framework.CIt("Create and delete echoheaders service with type LoadBalancer", func(ctx context.Context) {
 		f.createEchoheaders(ctx, true, true, 360*time.Second, 420*time.Second)


### PR DESCRIPTION
/area testing
/kind bug

1. Currently with `golang:1.16.6` the test execution fails with:
   Similar to 1. from https://github.com/gardener/gardener-extension-runtime-gvisor/pull/45

2. Next, the test execution failed with:

      ```
   Unknown Decorator
   BeforeEach(f.prepareClientsAndCluster, 60)
   /go/src/github.com/gardener/gardener-extension-shoot-dns-service/test/system/shootdns_test.go:178
     [BeforeEach] node was passed an unknown decorator: '60'
   ```
   
   `test/system/shootdns_test.go` had to be adapted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix developer
An issue causing the integration test execution to fail due to outdated golang version is now fixed.
```
