### PR TITLE
Improved liveness probe for admission webhook

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
@@ -46,15 +46,24 @@ spec:
         {{- if .Values.global.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-admission-shoot-dns-service/kubeconfig/kubeconfig
         {{- end }}
+        - --health-bind-address=:{{ .Values.global.healthPort }}
         ports:
         - name: webhook-server
           containerPort: {{ .Values.global.webhookConfig.serverPort }}
           protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: {{ .Values.global.webhookConfig.serverPort }}
+          httpGet:
+            path: /healthz
+            port: {{ .Values.global.healthPort }}
+            scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .Values.global.healthPort }}
+            scheme: HTTP
+          initialDelaySeconds: 5
 {{- if .Values.global.resources }}
         resources:
 {{ toYaml .Values.global.resources | nindent 10 }}

--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
@@ -9,6 +9,7 @@ global:
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}
+  healthPort: 8081
   vpa:
     enabled: true
     resourcePolicy:

--- a/vendor/github.com/gardener/gardener/pkg/healthz/default.go
+++ b/vendor/github.com/gardener/gardener/pkg/healthz/default.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthz
+
+import (
+	"sync"
+)
+
+// DefaultHealthManagerName is the name of the default health manager.
+const DefaultHealthManagerName = "default"
+
+// NewDefaultHealthz returns a default health manager that stores the given health status and returns it.
+func NewDefaultHealthz() Manager {
+	return &defaultHealthz{}
+}
+
+type defaultHealthz struct {
+	mutex   sync.RWMutex
+	health  bool
+	started bool
+}
+
+// Name returns the name of the health manager.
+func (d *defaultHealthz) Name() string {
+	return DefaultHealthManagerName
+}
+
+// Start starts the health manager.
+func (d *defaultHealthz) Start() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	d.started = true
+	d.health = true
+}
+
+// Stop stops the health manager.
+func (d *defaultHealthz) Stop() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	d.started = false
+	d.health = false
+}
+
+// Get returns the current health status.
+func (d *defaultHealthz) Get() bool {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.health
+}
+
+// Set sets the current health status.
+func (d *defaultHealthz) Set(health bool) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.health = health && d.started
+}

--- a/vendor/github.com/gardener/gardener/pkg/healthz/healthz.go
+++ b/vendor/github.com/gardener/gardener/pkg/healthz/healthz.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthz
+
+import (
+	"net/http"
+)
+
+// Manager is an interface for health managers.
+type Manager interface {
+	// Name returns the name of the health manager.
+	Name() string
+	// Start starts the health manager.
+	Start()
+	// Stop stops the health manager.
+	Stop()
+	// Get returns the current health status.
+	Get() bool
+	// Set updates the current health status with the given value.
+	Set(bool)
+}
+
+// HandlerFunc returns a HTTP handler that responds with 200 OK status code if the given health manager returns true,
+// otherwise 500 Internal Server Error status code will be returned.
+func HandlerFunc(h Manager) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !h.Get() {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/healthz/informer.go
+++ b/vendor/github.com/gardener/gardener/pkg/healthz/informer.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthz
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+type cacheSyncWaiter interface {
+	WaitForCacheSync(ctx context.Context) bool
+}
+
+// NewCacheSyncHealthz returns a new healthz.Checker that will pass only if all informers in the given cacheSyncWaiter sync.
+func NewCacheSyncHealthz(cacheSyncWaiter cacheSyncWaiter) healthz.Checker {
+	return func(_ *http.Request) error {
+		// cache.Cache.WaitForCacheSync is racy for closed context, so use context with 1ms timeout instead.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+
+		if !cacheSyncWaiter.WaitForCacheSync(ctx) {
+			return fmt.Errorf("informers not synced yet")
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/healthz/periodic.go
+++ b/vendor/github.com/gardener/gardener/pkg/healthz/periodic.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthz
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+)
+
+// PeriodicHealthManagerName is the name of the periodic health manager.
+const PeriodicHealthManagerName = "periodic"
+
+// NewPeriodicHealthz returns a health manager that automatically sets the health status to false after the given reset
+// duration. The timer is reset again when the health status is true (i.e., a running timer is reset and starts again
+// from the beginning).
+func NewPeriodicHealthz(clock clock.Clock, resetDuration time.Duration) Manager {
+	return &periodicHealthz{clock: clock, resetDuration: resetDuration}
+}
+
+type periodicHealthz struct {
+	clock         clock.Clock
+	mutex         sync.RWMutex
+	health        bool
+	timer         clock.Timer
+	resetDuration time.Duration
+	started       bool
+	stopCh        chan struct{}
+}
+
+// Name returns the name of the health manager.
+func (p *periodicHealthz) Name() string {
+	return PeriodicHealthManagerName
+}
+
+// Start starts the health manager.
+func (p *periodicHealthz) Start() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if p.started {
+		return
+	}
+
+	p.health = true
+	p.timer = p.clock.NewTimer(p.resetDuration)
+	p.started = true
+	p.stopCh = make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-p.timer.C():
+				p.Set(false)
+			case <-p.stopCh:
+				p.timer.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// Stop stops the health manager.
+func (p *periodicHealthz) Stop() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.health = false
+	if !p.started {
+		return
+	}
+
+	close(p.stopCh)
+	p.started = false
+}
+
+// Get returns the current health status.
+func (p *periodicHealthz) Get() bool {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	return p.health
+}
+
+// Set sets the current health status. When the health status is 'true' then the timer is reset.
+func (p *periodicHealthz) Set(health bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.health = health && p.started
+
+	if health && p.started {
+		p.timer.Reset(p.resetDuration)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,6 +103,7 @@ github.com/gardener/gardener/pkg/controllerutils/reconciler
 github.com/gardener/gardener/pkg/extensions
 github.com/gardener/gardener/pkg/gardenlet/apis/config
 github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1
+github.com/gardener/gardener/pkg/healthz
 github.com/gardener/gardener/pkg/logger
 github.com/gardener/gardener/pkg/mock/controller-runtime/client
 github.com/gardener/gardener/pkg/operation/botanist/component


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Replace TCP liveness probe with health check, add readiness probe to admission webhook.

**Special notes for your reviewer**:
similar to https://github.com/gardener/gardener-extension-networking-calico/pull/180

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved liveness probe for admission webhook
```
