### PR TITLE
Update limits limit. Disable limit autoscaling.

### DIFF
--- a/charts/internal/shoot-dns-service-seed/templates/vpa.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/vpa.yaml
@@ -8,6 +8,7 @@ spec:
   resourcePolicy:
     containerPolicies:
       - containerName: '*'
+        controlledValues: RequestsOnly
         minAllowed:
           cpu: {{ .Values.vpa.minAllowed.cpu }}
           memory: {{ .Values.vpa.minAllowed.memory }}

--- a/charts/internal/shoot-dns-service-seed/values.yaml
+++ b/charts/internal/shoot-dns-service-seed/values.yaml
@@ -31,8 +31,7 @@ resources:
     memory: "64Mi"
     cpu: "20m"
   limits:
-    memory: "128Mi"
-    cpu: "50m"
+    memory: "700Mi"
 
 vpa:
   enabled: true


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Sets absolute memory limit for the shoot-dns-service component per measured actual usage. Removes CPU limit of same component. Disables limit autoscaling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
A fixed memory limit was set for the shoot-dns-service component, in accordance with measurements of actual field usage. CPU limit of same container was removed.
```
