### PR TITLE
Update to golang-1.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.18.2 AS builder
+FROM golang:1.18.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-dns-service
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder for docker image to golang:v1.18.5

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
