### PR TITLE
Fix the Shoot DNS integration test

### DIFF
--- a/test/system/shootdns_test.go
+++ b/test/system/shootdns_test.go
@@ -89,16 +89,14 @@ func (f *shootDNSFramework) technicalShootId() string {
 
 func (f *shootDNSFramework) prepareClientsAndCluster() {
 	var err error
-	f.seedClient, err = kubernetes.NewClientFromFile("", f.config.SeedKubeconfig, kubernetes.WithClientOptions(
-		client.Options{
-			Scheme: kubernetes.SeedScheme,
-		}),
+	f.seedClient, err = kubernetes.NewClientFromFile("", f.config.SeedKubeconfig,
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+		kubernetes.WithDisabledCachedClient(),
 	)
 	framework.ExpectNoError(err)
-	f.shootClient, err = kubernetes.NewClientFromFile("", f.config.ShootKubeconfig, kubernetes.WithClientOptions(
-		client.Options{
-			Scheme: kubernetes.ShootScheme,
-		}),
+	f.shootClient, err = kubernetes.NewClientFromFile("", f.config.ShootKubeconfig,
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.ShootScheme}),
+		kubernetes.WithDisabledCachedClient(),
 	)
 	framework.ExpectNoError(err)
 
@@ -113,7 +111,7 @@ func (f *shootDNSFramework) prepareClientsAndCluster() {
 }
 
 func (f *shootDNSFramework) createNamespace(ctx context.Context, namespace string) *v1.Namespace {
-	f.Logger.Info("using namespace %s", namespace)
+	f.Logger.Info("Using namespace", "namespaceName", namespace)
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -127,12 +125,12 @@ func (f *shootDNSFramework) createNamespace(ctx context.Context, namespace strin
 }
 
 func (f *shootDNSFramework) deleteNamespaceAndWait(ctx context.Context, ns *v1.Namespace) {
-	f.Logger.Info("deleting namespace %s", ns.Name)
+	f.Logger.Info("Deleting namespace", "namespaceName", ns.Name)
 	err := f.shootClient.Client().Delete(ctx, ns)
 	framework.ExpectNoError(err)
 	err = f.WaitUntilNamespaceIsDeleted(ctx, f.shootClient, ns.Name)
 	framework.ExpectNoError(err)
-	f.Logger.Info("deleted namespace %s", ns.Name)
+	f.Logger.Info("Deleted namespace", "namespaceName", ns.Name)
 }
 
 func (f *shootDNSFramework) createEchoheaders(ctx context.Context, svcLB, delete bool,
@@ -165,7 +163,7 @@ func (f *shootDNSFramework) createEchoheaders(ctx context.Context, svcLB, delete
 	if delete {
 		f.deleteNamespaceAndWait(ctx, ns)
 	} else {
-		f.Logger.Info("no cleanup of namespace %s", ns.Name)
+		f.Logger.Info("No cleanup of namespace", "namespaceName", ns.Name)
 	}
 }
 


### PR DESCRIPTION
/area testing
/kind bug

**What this PR does / why we need it**:
Currently the Shoot DNS integration test fails with:
```
2022-08-15T08:03:19.906656783Z stdout F   In [BeforeEach] at: /src/test/system/shootdns_test.go:106
2022-08-15T08:03:19.906651126Z stdout F   occurred
2022-08-15T08:03:19.906645605Z stdout F       the cache is not started, can not read objects
2022-08-15T08:03:19.906640235Z stdout F       <*cache.ErrCacheNotStarted | 0x3541280>: {}
2022-08-15T08:03:19.906634636Z stdout F   Unexpected error:
```

![Screenshot 2022-08-15 at 17 16 56](https://user-images.githubusercontent.com/9372594/184652509-4694d606-e0cf-4696-ae6d-4732a09e445b.png)


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing the Shoot DNS integration test to fail is now fixed.
```
