### PR TITLE
Fix indentation for controllerdeployment

### DIFF
--- a/docs/installation/setup.md
+++ b/docs/installation/setup.md
@@ -49,23 +49,23 @@ providerConfig:
   values:
     image:
       ...
-  dnsControllerManager:
-    configuration:
-      cacheTtl: 300
-      controllers: dnscontrollers,dnssources
-      dnsPoolResyncPeriod: 30m
-      #poolSize: 20
-      #providersPoolResyncPeriod: 24h
-      serverPortHttp: 8080
-    createCRDs: false
-    deploy: true
-    replicaCount: 1
-    #resources:
-    #  limits:
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 50m
-    #    memory: 500Mi
+    dnsControllerManager:
+      configuration:
+        cacheTtl: 300
+        controllers: dnscontrollers,dnssources
+        dnsPoolResyncPeriod: 30m
+        #poolSize: 20
+        #providersPoolResyncPeriod: 24h
+        serverPortHttp: 8080
+      createCRDs: false
+      deploy: true
+      replicaCount: 1
+      #resources:
+      #  limits:
+      #    memory: 1Gi
+      #  requests:
+      #    cpu: 50m
+      #    memory: 500Mi
 ```
 
 ### Providing Base Domains usable for a Shoot


### PR DESCRIPTION
Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
This PR fixes the indentation for the example ``ControllerDeployment``.

**Special notes for your reviewer**:
The default value tag is latest. Please be aware, that this image tag doesn't exist and you have to reference a tag like ``v0.13.2``

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
