### PR TITLE
Enable DNSProvider management and add image section

### DIFF
--- a/docs/installation/setup.md
+++ b/docs/installation/setup.md
@@ -47,6 +47,9 @@ providerConfig:
     image:
       ...
     dnsControllerManager:
+      image:
+        repository: eu.gcr.io/gardener-project/dns-controller-manager
+        tag: v0.13.3
       configuration:
         cacheTtl: 300
         controllers: dnscontrollers,dnssources
@@ -63,6 +66,8 @@ providerConfig:
       #  requests:
       #    cpu: 50m
       #    memory: 500Mi
+    dnsProviderManagement:
+      enabled: true
 ```
 
 ### Providing Base Domains usable for a Shoot


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve example for enabling dns-controller-manager:
Enable DNSProvider management and add image section.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Enable DNSProvider management and add image section
```
