### PR TITLE
Fix integration test TestDefinition

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -17,4 +17,4 @@ spec:
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/3rd/golang:1.17.9
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.3


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Current execution of the integration test fails with:
```
# k8s.io/apimachinery/third_party/forked/golang/reflect
vendor/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go:376:7: undefined: reflect.Pointer
note: module requires Go 1.19
# k8s.io/apimachinery/pkg/util/validation/field
vendor/k8s.io/apimachinery/pkg/util/validation/field/errors.go:69:33: undefined: reflect.Pointer
note: module requires Go 1.19
# k8s.io/apimachinery/pkg/conversion/queryparams
vendor/k8s.io/apimachinery/pkg/conversion/queryparams/convert.go:58:17: undefined: reflect.Pointer
vendor/k8s.io/apimachinery/pkg/conversion/queryparams/convert.go:142:7: undefined: reflect.Pointer
note: module requires Go 1.19
# sigs.k8s.io/json/internal/golang/encoding/json
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:96:31: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:177:35: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:428:37: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:937:48: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:1143:45: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:1160:42: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:1195:52: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/decode.go:1261:42: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:158:16: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:175:22: undefined: any
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:175:22: too many errors
note: module requires Go 1.18
# k8s.io/apimachinery/third_party/forked/golang/json
vendor/k8s.io/apimachinery/third_party/forked/golang/json/fields.go:31:17: undefined: reflect.Pointer
vendor/k8s.io/apimachinery/third_party/forked/golang/json/fields.go:186:40: undefined: reflect.Pointer
note: module requires Go 1.19
# k8s.io/apimachinery/pkg/util/diff
vendor/k8s.io/apimachinery/pkg/util/diff/diff.go:138:28: undefined: reflect.Pointer
note: module requires Go 1.19
FAIL	github.com/gardener/gardener-extension-shoot-dns-service/test/system [build failed]
FAIL
```

This is due to outdated go version in the TestDefinition.

**Which issue(s) this PR fixes**:
See above.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing the integration test execution to fail due to outdated golang version is now fixed.
```
