### PR TITLE
Deploy the dns-controller-manager by default

### DIFF
--- a/charts/gardener-extension-shoot-dns-service/values.yaml
+++ b/charts/gardener-extension-shoot-dns-service/values.yaml
@@ -62,7 +62,7 @@ remoteDefaultDomainSecret:
 #    tls.key: LS0tLS1...
 
 dnsControllerManager:
-  deploy: false
+  deploy: true
   image:
     repository: eu.gcr.io/gardener-project/dns-controller-manager
     tag: latest


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt

**What this PR does / why we need it**:
As the dns-controller-manager should typically be deployed together with the extension controller itself, the default value is changed from `false` to `true`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
