### PR TITLE
Fix set_dependency_version_dnsman

### DIFF
--- a/hack/.ci/set_dependency_version_dnsman
+++ b/hack/.ci/set_dependency_version_dnsman
@@ -29,7 +29,7 @@ values_file = pathlib.Path(
 )
 temp_file = values_file.parent.joinpath('~values.yaml.tmp~')
 
-if dependency_name == 'external-dns-management':
+if dependency_name == 'github.com/gardener/external-dns-management':
   print(f'updating tag for dnsControllerManager to "{dependency_version}"')
   with open(temp_file, 'w') as fout:
     with open(values_file, 'r') as fin:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix set_dependency_version_dnsman introduced with #179

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
