### PR TITLE
Fix set_dependency_version

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -3,3 +3,5 @@
 "$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version
 
 "$(dirname $0)"/../hack/.ci/set_dependency_version_dnsman
+
+make generate


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix set_dependency_version


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
