### PR TITLE
Fix set_dependency_version

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -15,5 +15,5 @@ export PATH=/tmp:$PATH
 apk add tar
 
 # generate example/controller-registration.yaml
-cd charts/gardener-extension-shoot-dns-service
+cd "$(dirname $0)"/../charts/gardener-extension-shoot-dns-service
 ../../vendor/github.com/gardener/gardener/hack/generate-controller-registration.sh extension-shoot-dns-service . $(cat ../../VERSION) ../../example/controller-registration.yaml Extension:shoot-dns-service


### PR DESCRIPTION
**What this PR does / why we need it**:
Another fix for set_dependency_version

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
