### PR TITLE
Use provider specific regex to parse error codes from error

### DIFF
--- a/pkg/apis/helper/error_codes.go
+++ b/pkg/apis/helper/error_codes.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"regexp"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+var (
+	unauthenticatedRegexp    = regexp.MustCompile(`(?i)(InvalidAuthenticationTokenTenant|Authentication failed|AuthFailure|invalid character|invalid_client|query returned no results|InvalidAccessKeyId|cannot fetch token|InvalidSecretAccessKey|InvalidSubscriptionId)`)
+	unauthorizedRegexp       = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|SignatureDoesNotMatch|AuthorizationFailed|invalid_grant|Authorization Profile was not found|no active subscriptions|UnauthorizedOperation|not authorized|AccessDenied|OperationNotAllowed|Error 403|SERVICE_ACCOUNT_ACCESS_DENIED)`)
+	quotaExceededRegexp      = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded|Quotas|Quota.*exceeded|exceeded quota|Quota has been met|QUOTA_EXCEEDED|Maximum number of ports exceeded|ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS)`)
+	rateLimitsExceededRegexp = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling|Too many requests)`)
+
+	// KnownCodes maps Gardener error codes to respective regex.
+	KnownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
+		gardencorev1beta1.ErrorInfraUnauthenticated:    unauthenticatedRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraUnauthorized:       unauthorizedRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraQuotaExceeded:      quotaExceededRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraRateLimitsExceeded: rateLimitsExceededRegexp.MatchString,
+	}
+)

--- a/pkg/controller/lifecycle/dnsprovider.go
+++ b/pkg/controller/lifecycle/dnsprovider.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/helper"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -31,6 +30,8 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/helper"
 )
 
 // TimeNow returns the current time. Exposed for testing.

--- a/pkg/controller/lifecycle/dnsprovider.go
+++ b/pkg/controller/lifecycle/dnsprovider.go
@@ -20,8 +20,9 @@ import (
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/helper"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -132,7 +133,7 @@ func CheckDNSProvider(obj client.Object) error {
 			// faster, without retrying until the entire timeout is elapsed.
 			// This is the same behavior as in other extension components which leverage health.CheckExtensionObject, where
 			// ErrorWithCodes is returned if status.lastError is set (no matter if status.lastError.codes contains error codes).
-			err = retry.RetriableError(gardencorev1beta1helper.DeprecatedDetermineError(err))
+			err = retry.RetriableError(util.DetermineError(err, helper.KnownCodes))
 		}
 		return &errorWithDNSState{underlying: err, state: state}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR removes extension dependency on g/g to extract error codes from errors and uses regex defined in the extension repo. Later extensions can be adapted to map provider-specific error codes to gardener error codes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5444

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Provider-specific error codes are now detected/parsed on the extension side.
```
