### PR TITLE
Fix nil pointer when rendering runtime chart separately

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
@@ -42,3 +42,6 @@ global:
     enabled: false
     expirationSeconds: 43200
     audience: ""
+  service:
+    topologyAwareRouting:
+      enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-shoot-dns-service/commit/1f2a60e7ba5a22d014de91a6a9a126e46efe8339 introduced configurable topology awareness to the runtime chart and added a corresponding global value to the parent chart.

When deploying / rendering the runtime chart separately, [this](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/v1.32.0/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/service.yaml#L6) will cause a nil pointer as the path `.Values.global.service.topologyAwareRouting` is not defined.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @MartinWeindel @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix nil pointer when rendering runtime chart separately.
```
