### PR TITLE
[release-v1.32] Automated cherry pick of #204: Fix nil pointer when rendering runtime chart separately

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
@@ -42,3 +42,6 @@ global:
     enabled: false
     expirationSeconds: 43200
     audience: ""
+  service:
+    topologyAwareRouting:
+      enabled: false


### PR DESCRIPTION
/area quality
/kind bug

Cherry pick of #204 on release-v1.32.

#204: Fix nil pointer when rendering runtime chart separately

**Release Notes:**
```bugfix operator
Fix nil pointer when rendering the gardener-extension-admission-shoot-dns-service runtime chart separately.
```