### PR TITLE
Fix the TestDefinition's image

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -17,4 +17,4 @@ spec:
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/3rd/golang:1.20.2
+  image: golang:1.20.3


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
`eu.gcr.io/gardener-project/3rd/golang:1.20.2` does not exist:
```
% docker pull eu.gcr.io/gardener-project/3rd/golang:1.20.2
Error response from daemon: manifest for eu.gcr.io/gardener-project/3rd/golang:1.20.2 not found: manifest unknown: Failed to fetch "1.20.2" from request "/v2/gardener-project/3rd/golang/manifests/1.20.2".
```

In gardener/gardener with https://github.com/gardener/gardener/pull/7553 we adapted all of the TestDefinitions to use the upstream go image and that's why we didn't push/maintain a 1.20 for `eu.gcr.io/gardener-project/3rd/golang`

After #200 the shoot-dns test fails because of the missing image:
![Screenshot 2023-04-27 at 12 30 36](https://user-images.githubusercontent.com/9372594/234821608-ce8eb7e8-65f5-4f94-abeb-936f744d28b8.png)


**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```developer bugfix
The TestDefinition does now point to the upstream golang image. Previously it was referring a missing golang image.
```
