### PR TITLE
Bump golang image to 1.20.3

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -17,4 +17,4 @@ spec:
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/3rd/golang:1.20.2
+  image: golang:1.20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.20.2 AS builder
+FROM golang:1.20.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-dns-service
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golang image to 1.20.3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump builder image from `golang:1.20.2` to `golang:1.20.3`
```

```developer bugfix
The TestDefinition does now point to the upstream golang image. Previously it was referring a missing golang image.
```
