### PR TITLE
Exclude external kube-apiserver domain from the `external` DNSProvider

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -569,6 +569,7 @@ func (a *actuator) prepareDefaultExternalDNSProvider(ctx context.Context, _ *api
 		return &apisservice.DNSProvider{
 			Domains: &apisservice.DNSIncludeExclude{
 				Include: []string{*cluster.Shoot.Spec.DNS.Domain},
+				Exclude: []string{"api." + *cluster.Shoot.Spec.DNS.Domain}, // exclude external kube-apiserver domain
 			},
 			SecretName: &secretName,
 			Type:       &remoteType,
@@ -582,6 +583,7 @@ func (a *actuator) prepareDefaultExternalDNSProvider(ctx context.Context, _ *api
 	provider := &apisservice.DNSProvider{
 		Domains: &apisservice.DNSIncludeExclude{
 			Include: []string{*cluster.Shoot.Spec.DNS.Domain},
+			Exclude: []string{"api." + *cluster.Shoot.Spec.DNS.Domain}, // exclude external kube-apiserver domain
 		},
 		SecretName: &secretRef.Name,
 		Type:       &providerType,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Users can create an DNSEntry for the external kube-apiserver domain. As the `DNSRecord` controllers are not using metadata records as the DNS controller manager, the record would be replaced silently.
To avoid such a case, the `external` DNSProvider excludes the kube-apiserver domain explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Exclude external kube-apiserver domain from the `external` DNSProvider
```
