### PR TITLE
Update golang to version 1.20.5

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -12,7 +12,7 @@ curl -sSfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 export PATH=/tmp:$PATH
 
 # install gnutar
-apk add tar
+apk add tar yq
 
 # generate example/controller-registration.yaml
 cd "$(dirname $0)"/../charts/gardener-extension-shoot-dns-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.20.4 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-dns-service
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang image to version `1.20.5`.

Fix `.ci/set_dependency_version` by adding yq to image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update golang image from version `1.20.4` to `1.20.5`.
```
