### PR TITLE
Fail if reading secret for external provider fails

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -332,7 +332,7 @@ func (a *actuator) createOrUpdateDNSProviders(ctx context.Context, log logr.Logg
 	if !a.isHibernated(cluster) {
 		external, err := a.prepareDefaultExternalDNSProvider(ctx, dnsconfig, namespace, cluster)
 		if err != nil {
-			result = multierror.Append(result, err)
+			return err
 		}
 
 		resources := cluster.Shoot.Spec.Resources


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The error handling on updating DNS providers is fixed for the following edge case: There is an error on reading the secret for the `external` provider. In this case the error is only recorded and the `external` `DNSProvider` is deleted.
The correct behaviour is to stop processing and return the error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fail if reading secret for external provider fails.
```
