### PR TITLE
Add support for projected volume kubeconfig

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
         {{- if .Values.global.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-admission-shoot-dns-service/kubeconfig/kubeconfig
         {{- end }}
+        {{- if .Values.global.projectedKubeconfig }}
+        - --kubeconfig={{ required ".Values.global.projectedKubeconfig.baseMountPath is required" .Values.global.projectedKubeconfig.baseMountPath }}/kubeconfig
+        {{- end }}
         - --health-bind-address=:{{ .Values.global.healthPort }}
         ports:
         - name: webhook-server
@@ -85,6 +88,10 @@ spec:
           mountPath: /var/run/secrets/projected/serviceaccount
           readOnly: true
         {{- end }}
+        - name: kubeconfig
+          mountPath: {{ required ".Values.global.projectedKubeconfig.baseMountPath is required" .Values.global.projectedKubeconfig.baseMountPath }}
+          readOnly: true
+        {{- end }}
       volumes:
       - name: gardener-extension-admission-shoot-dns-service-cert
         secret:
@@ -106,4 +113,21 @@ spec:
               {{- if .Values.global.serviceAccountTokenVolumeProjection.audience }}
               audience: {{ .Values.global.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
+      {{- end }}
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.global.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.global.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.global.projectedKubeconfig.tokenSecretName is required" .Values.global.projectedKubeconfig.tokenSecretName }}
+              optional: false
       {{- end }}

--- a/charts/gardener-extension-admission-shoot-dns-service/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/values.yaml
@@ -38,6 +38,11 @@ global:
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
 
+# projectedKubeconfig:
+#   baseMountPath: /var/run/secrets/gardener.cloud
+#   genericKubeconfigSecretName: generic-token-kubeconfig
+#   tokenSecretName: access-dns-admission
+
   serviceAccountTokenVolumeProjection:
     enabled: false
     expirationSeconds: 43200


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds the option to configure a projected volume for the validator which can be used as a kubeconfig. It is for example needed, if operators generate their kubeconfigs for the virtual garden cluster via the [TokenRequestor](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokeninvalidator-controller).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-extension-admission-shoot-dns-service` chart allows to optionally configure a projected volume based kubeconfig.
```
