### PR TITLE
Fix admission chart

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
@@ -88,6 +88,7 @@ spec:
           mountPath: /var/run/secrets/projected/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if .Values.global.projectedKubeconfig }}
         - name: kubeconfig
           mountPath: {{ required ".Values.global.projectedKubeconfig.baseMountPath is required" .Values.global.projectedKubeconfig.baseMountPath }}
           readOnly: true
@@ -114,6 +115,7 @@ spec:
               audience: {{ .Values.global.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
       {{- end }}
+      {{- if .Values.global.projectedKubeconfig }}
       - name: kubeconfig
         projected:
           defaultMode: 420


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Fixes a bug introduced with #232.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed in the `gardener-extension-admission-shoot-dns-service` chart that relates to the projected kubeconfig feature.
```
