### PR TITLE
Add copy of images.yaml to charts dir to resolve RBSC issue

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -3,6 +3,8 @@
 set -e
 
 "$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version
+# update copy in charts directory needed for installation after RBSC sync
+cp "$(dirname $0)"/../imagevector/images.yaml "$(dirname $0)"/../charts/images.yaml
 
 "$(dirname $0)"/../hack/.ci/set_dependency_version_dnsman
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,0 +1,5 @@
+images:
+- name: dns-controller-manager
+  sourceRepository: github.com/gardener/external-dns-management
+  repository: eu.gcr.io/gardener-project/dns-controller-manager
+  tag: "v0.15.8"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Only the charts folder is available for landscape setup for landscapes synced by RBSC.
As `images.yaml` is read during installation via landscape setup, it must be available in the charts folder, too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add copy of images.yaml to charts dir to resolve installation issue for landscapes using RBSC
```
