### PR TITLE
Add `resources.gardener.cloud/skip-health-check=true` annotation to CRDs

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -736,6 +736,10 @@ func (a *actuator) createOrUpdateShootResources(ctx context.Context, dnsconfig *
 	}
 	cleanCRD(crd)
 
+	annotations := crd.GetAnnotations()
+	annotations[resourcesv1alpha1.SkipHealthCheck] = "true"
+	crd.SetAnnotations(annotations)
+
 	crd2 := &unstructured.Unstructured{}
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, _, err := dec.Decode([]byte(dnsAnnotationCRD), nil, crd2)

--- a/pkg/controller/lifecycle/dnsAnnotationCRD.yaml
+++ b/pkg/controller/lifecycle/dnsAnnotationCRD.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dnsannotations.dns.gardener.cloud
+  annotations:
+    resources.gardener.cloud/skip-health-check: "true"
 spec:
   conversion:
     strategy: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Add `resources.gardener.cloud/skip-health-check=true` annotation to CRDs. Otherwise, `gardener-resource-manager` might recreate them too fast during shoot deletion after `gardenlet` just deleted them (and expects them to be gone). This can lead to race conditions, especially after https://github.com/gardener/gardener/issues/7473.

This is just a workaround for now and needs to be figured out properly.

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `CustomResourceDefinition`s deployed to shoot clusters are now annotated with `resources.gardener.cloud/skip-health-check=true` to prevent `gardener-resource-manager` from recreating them too fast during shoot deletion.
```
