### PR TITLE
Add shoot.gardener.cloud/no-cleanup=true label to CRDs

### DIFF
--- a/pkg/controller/lifecycle/dnsAnnotationCRD.yaml
+++ b/pkg/controller/lifecycle/dnsAnnotationCRD.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dnsannotations.dns.gardener.cloud
-  annotations:
-    resources.gardener.cloud/skip-health-check: "true"
 spec:
   conversion:
     strategy: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Add shoot.gardener.cloud/no-cleanup=true label to CRDs to avoid Gardenlet to delete CRDs and GRM recreating them.
As `DNSEntries` are replicated to the control plane, it is not mandatory to delete them (or their source objects) in the shoot cluster.
Additionally reverts https://github.com/gardener/gardener-extension-shoot-dns-service/pull/240 as not needed anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `CustomResourceDefinition`s deployed to shoot clusters are now labelled with `shoot.gardener.cloud/no-cleanup=true` to prevent `gardenlet` to deleting them during shoot deletion.
```
