### PR TITLE
Validate shoots without DNS config

### DIFF
--- a/pkg/admission/mutator/shoot_mutator.go
+++ b/pkg/admission/mutator/shoot_mutator.go
@@ -50,25 +50,16 @@ type shoot struct {
 }
 
 // Mutate implements extensionswebhook.Mutator.Mutate
-func (s *shoot) Mutate(ctx context.Context, new, old client.Object) error {
+func (s *shoot) Mutate(ctx context.Context, new, _ client.Object) error {
 	shoot, ok := new.(*gardencorev1beta1.Shoot)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", new)
 	}
 
-	var oldShoot *gardencorev1beta1.Shoot
-	if old != nil {
-		var ok bool
-		oldShoot, ok = old.(*gardencorev1beta1.Shoot)
-		if !ok {
-			return fmt.Errorf("wrong object type %T for old object", old)
-		}
-	}
-
-	return s.mutateShoot(ctx, oldShoot, shoot)
+	return s.mutateShoot(ctx, shoot)
 }
 
-func (s *shoot) mutateShoot(_ context.Context, _, new *gardencorev1beta1.Shoot) error {
+func (s *shoot) mutateShoot(_ context.Context, new *gardencorev1beta1.Shoot) error {
 	if s.isDisabled(new) {
 		return nil
 	}

--- a/pkg/admission/validator/shoot_validator.go
+++ b/pkg/admission/validator/shoot_validator.go
@@ -44,25 +44,16 @@ type shoot struct {
 }
 
 // Validate implements extensionswebhook.Validator.Validate
-func (s *shoot) Validate(ctx context.Context, new, old client.Object) error {
+func (s *shoot) Validate(ctx context.Context, new, _ client.Object) error {
 	shoot, ok := new.(*core.Shoot)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", new)
 	}
 
-	var oldShoot *core.Shoot
-	if old != nil {
-		var ok bool
-		oldShoot, ok = old.(*core.Shoot)
-		if !ok {
-			return fmt.Errorf("wrong object type %T for old object", old)
-		}
-	}
-
-	return s.validateShoot(ctx, oldShoot, shoot)
+	return s.validateShoot(ctx, shoot)
 }
 
-func (s *shoot) validateShoot(_ context.Context, _, shoot *core.Shoot) error {
+func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
 	if s.isDisabled(shoot) {
 		return nil
 	}
@@ -81,9 +72,6 @@ func (s *shoot) validateShoot(_ context.Context, _, shoot *core.Shoot) error {
 
 // isDisabled returns true if extension is explicitly disabled.
 func (s *shoot) isDisabled(shoot *core.Shoot) bool {
-	if shoot.Spec.DNS == nil {
-		return true
-	}
 	ext := s.findExtension(shoot)
 	if ext == nil {
 		return false
@@ -110,9 +98,6 @@ func (s *shoot) extractDNSConfig(shoot *core.Shoot) (*apisservice.DNSConfig, err
 
 // findExtension returns shoot-dns-service extension.
 func (s *shoot) findExtension(shoot *core.Shoot) *core.Extension {
-	if shoot.Spec.DNS == nil {
-		return nil
-	}
 	for i, ext := range shoot.Spec.Extensions {
 		if ext.Type == service.ExtensionType {
 			return &shoot.Spec.Extensions[i]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Gardener allows to create shoots without `shoot.Spec.DNS` and instead defaults this config throughout the creation process.

However, the `shoot-dns-service` validation was skipped for such shoots because defaulting happens later in the chain.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue was fixed that caused shoot clusters with a `shoot-dns-service` extension configuration not to be validated during creation. Potential validation errors only happened later and remained unnoticed, e.g. when update requests from Gardenlet were denied and shoot reconciliation got stuck.
```
