### PR TITLE
Update dependabot workflow after removing vendoring

### DIFF
--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -1,4 +1,4 @@
-name: Vendor Gardener
+name: Update copied files from Gardener
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
 permissions: write-all
 jobs:
   run:
-    name: Run make revendor
+    name: Run make tidy
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -14,8 +14,8 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Make revendor
-      run: make revendor
+    - name: Make tidy
+      run: make tidy
     - name: Commit changes
       run: |
         # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
@@ -27,5 +27,5 @@ jobs:
         git config user.name gardener-robot-ci-1
         git config user.email gardener.ci.user@gmail.com
         git add .
-        git commit -m "[dependabot skip] make revendor"
+        git commit -m "[dependabot skip] make tidy"
         git push origin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Update dependabot workflow:
Replace 'make vendor' with 'make tidy' to update copied files in `.ci/hack` from gardener/gardener

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
follow-up of #268 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
