### PR TITLE
Fix admission controller permissions

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - watch
   - update
   - patch
+  - delete
 - apiGroups:
   - coordination.k8s.io
   resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
After switching to self-managed certificates in https://github.com/gardener/gardener-extension-shoot-dns-service/pull/266, the `certificate` controller in the admission controller needs permissions to delete `Secret`s. Certificate rotation is achieved by creating new immutable secrets and deleting the old ones. The controller will not only be able to clean up unneeded secrets, but runs also into a unrecoverable issue since the certificate `reloader` expects only to find one secret ([ref](https://github.com/gardener/gardener/blob/01b5894e86b97e6d17ec86e487b7fdb1d6870b87/extensions/pkg/webhook/certificates/reloader.go#L167))

```
"2 errors occurred:
	* secrets "ca-admission-shoot-dns-service-webhook-bundle-bb86480d" is forbidden: User "system:serviceaccount:garden:gardener-extension-admission-shoot-dns-service" cannot delete resource "secrets" in API group "" in the namespace "garden"
	* secrets "admission-shoot-dns-service-webhook-server-ffa12640" is forbidden: User "system:serviceaccount:garden:gardener-extension-admission-shoot-dns-service" cannot delete resource "secrets" in API group "" in the namespace "garden"
"
```

**Special notes for your reviewer**:
/cc @MartinWeindel @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that led to invalid webhook configurations after the admission controller rotated the CA and server certificates.
```
