### PR TITLE
Update the golang version for the TestDefinition

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -17,4 +17,4 @@ spec:
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: golang:1.20.4
+  image: golang:1.21.5


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Right now the test execution fails with:
```
2024-01-10T11:31:36.713369897Z stderr F /go/pkg/mod/github.com/gardener/gardener@v1.86.0/pkg/utils/gardener/shoot.go:18:2: package cmp is not in GOROOT (/usr/local/go/src/cmp)
2024-01-10T11:31:36.713372651Z stderr F note: imported by a module that requires go 1.21
2024-01-10T11:31:36.713393399Z stdout F FAIL	github.com/gardener/gardener-extension-shoot-dns-service/test/system [setup failed]
2024-01-10T11:31:36.713447049Z stdout F FAIL
2024-01-10T11:31:37.151234231Z stderr F time="2024-01-10T11:31:37.151Z" level=info msg="sub-process exited" argo=true error="<nil>"
2024-01-10T11:31:37.151352643Z stderr F time="2024-01-10T11:31:37.151Z" level=warning msg="cannot save artifact /tmp/tm/export" argo=true error="stat /tmp/tm/export: no such file or directory"
2024-01-10T11:31:37.152264985Z stderr F Error: exit status 1
```

The `cmp` pkg is introduced in go@1.21. The test is being executed with go@1.20.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the testmachinery test to fail to due to an outdated golang version in the TestDefinition is now fixed.
```
