### PR TITLE
Bump golang version in TestDefinition to 1.22.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,7 @@ updates:
   directory: /
   schedule:
     interval: daily
+- package-ecosystem: docker
+  directory: /.test-defs
+  schedule:
+    interval: daily

--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -11,10 +11,10 @@ spec:
   command: [bash, -c]
   args:
     - >-
-      go test -timeout=0 -mod=mod ./test/system
+      go test -timeout=0 ./test/system
       --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       -seed-kubecfg=$TM_KUBECONFIG_PATH/seed.config
       -shoot-kubecfg=$TM_KUBECONFIG_PATH/shoot.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
-  image: golang:1.21.5
+  image: golang:1.22.0

--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -1,3 +1,4 @@
+apiVersion: testmachinery.sapcloud.io
 kind: TestDefinition
 metadata:
   name: shootdns-test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Currently the test execution currently fails with:
```
2024-02-29T12:49:15.472034131Z stderr F time="2024-02-29T12:49:15.471Z" level=info msg="capturing logs" argo=true
2024-02-29T12:49:15.476713874Z stderr F go: go.mod requires go >= 1.22.0 (running go 1.21.5; GOTOOLCHAIN=local)
2024-02-29T12:49:16.472789458Z stderr F time="2024-02-29T12:49:16.472Z" level=info msg="sub-process exited" argo=true error="<nil>"
2024-02-29T12:49:16.472830978Z stderr F time="2024-02-29T12:49:16.472Z" level=warning msg="cannot save artifact /tmp/tm/export" argo=true error="stat /tmp/tm/export: no such file or directory"
2024-02-29T12:49:16.47394268Z stderr F Error: exit status 1
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue caused the test execution to fail due to outdated go version in the TestDefinition is now fixed.
```
