### PR TITLE
Add error codes on deletion and no domain errors

### DIFF
--- a/pkg/apis/helper/error_codes.go
+++ b/pkg/apis/helper/error_codes.go
@@ -15,6 +15,7 @@ var (
 	unauthorizedRegexp       = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|SignatureDoesNotMatch|AuthorizationFailed|invalid_grant|Authorization Profile was not found|no active subscriptions|UnauthorizedOperation|not authorized|AccessDenied|OperationNotAllowed|Error 403|SERVICE_ACCOUNT_ACCESS_DENIED)`)
 	quotaExceededRegexp      = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded|Quotas|Quota.*exceeded|exceeded quota|Quota has been met|QUOTA_EXCEEDED|Maximum number of ports exceeded|ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS)`)
 	rateLimitsExceededRegexp = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling|Too many requests)`)
+	configurationRegexp      = regexp.MustCompile("(?i)(no domain matching hosting zones)")
 
 	// KnownCodes maps Gardener error codes to respective regex.
 	KnownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
@@ -22,5 +23,6 @@ var (
 		gardencorev1beta1.ErrorInfraUnauthorized:       unauthorizedRegexp.MatchString,
 		gardencorev1beta1.ErrorInfraQuotaExceeded:      quotaExceededRegexp.MatchString,
 		gardencorev1beta1.ErrorInfraRateLimitsExceeded: rateLimitsExceededRegexp.MatchString,
+		gardencorev1beta1.ErrorConfigurationProblem:    configurationRegexp.MatchString,
 	}
 )

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/helper"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/extension"
 	"github.com/gardener/gardener/extensions/pkg/util"
@@ -51,6 +50,7 @@ import (
 
 	"github.com/gardener/gardener-extension-shoot-dns-service/charts"
 	"github.com/gardener/gardener-extension-shoot-dns-service/imagevector"
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/helper"
 	apisservice "github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/service"
 	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/service/validation"
 	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/common"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Add Gardener error codes on DNS deletion and "no domain matching" errors.

**Which issue(s) this PR fixes**:
Fixes #298 and #300

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add Gardener error codes on DNS deletion and "no domain matching" errors.
```
