### PR TITLE
Allow DNS provider type `rfc2136`

### DIFF
--- a/pkg/apis/service/validation/validation.go
+++ b/pkg/apis/service/validation/validation.go
@@ -25,6 +25,7 @@ var supportedProviderTypes = []string{
 	"netlify-dns",
 	"openstack-designate",
 	"remote",
+	"rfc2136",
 }
 
 // ValidateDNSConfig validates the passed DNSConfig.

--- a/pkg/apis/service/validation/validation_test.go
+++ b/pkg/apis/service/validation/validation_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Validation", func() {
 			"Type":     Equal(field.ErrorTypeInvalid),
 			"Field":    Equal("spec.extensions.[@.type='shoot-dns-service'].providerConfig[0].type"),
 			"BadValue": Equal("dummy"),
-			"Detail":   Equal("unsupported provider type. Valid types are: alicloud-dns, aws-route53, azure-dns, azure-private-dns, cloudflare-dns, google-clouddns, infoblox-dns, netlify-dns, openstack-designate, remote"),
+			"Detail":   Equal("unsupported provider type. Valid types are: alicloud-dns, aws-route53, azure-dns, azure-private-dns, cloudflare-dns, google-clouddns, infoblox-dns, netlify-dns, openstack-designate, remote, rfc2136"),
 		})),
 		Entry("missing secret name", service.DNSConfig{
 			Providers: modifyCopy(valid[1:], func(items []service.DNSProvider) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The dns-controller-manager supports the DNS provider type `rfc2136` since [v0.15.10](https://github.com/gardener/external-dns-management/releases/tag/v0.15.10), but the shoot-dns-service validation webhook rejects it as it does not know the new type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see https://github.com/gardener/external-dns-management/pull/331

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Allow DNS provider type `rfc2136`
```
