### PR TITLE
Don't skip validation for missing provider secret resources if `spec.resources` is undefined in shoot manifest

### DIFF
--- a/pkg/apis/service/validation/validation.go
+++ b/pkg/apis/service/validation/validation.go
@@ -51,7 +51,7 @@ func validateProviders(providers []service.DNSProvider, resources []core.NamedRe
 		}
 		if p.SecretName == nil || *p.SecretName == "" {
 			allErrs = append(allErrs, field.Required(path.Index(i).Child("secretName"), "secret name is required"))
-		} else if resources != nil {
+		} else {
 			found := false
 			for _, ref := range resources {
 				if ref.Name == *p.SecretName {

--- a/pkg/apis/service/validation/validation_test.go
+++ b/pkg/apis/service/validation/validation_test.go
@@ -92,6 +92,20 @@ var _ = Describe("Validation", func() {
 			"BadValue": Equal("my-secret1"),
 			"Detail":   Equal("secret name is not defined as named resource references at 'spec.resources'"),
 		})),
+		Entry("missing resources", service.DNSConfig{
+			Providers: valid,
+		}, nil, matchers.ConsistOfFields(Fields{
+			"Type":     Equal(field.ErrorTypeInvalid),
+			"Field":    Equal("spec.extensions.[@.type='shoot-dns-service'].providerConfig[0].secretName"),
+			"BadValue": Equal("my-secret1"),
+			"Detail":   Equal("secret name is not defined as named resource references at 'spec.resources'"),
+		},
+			Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.extensions.[@.type='shoot-dns-service'].providerConfig[1].secretName"),
+				"BadValue": Equal("my-secret2"),
+				"Detail":   Equal("secret name is not defined as named resource references at 'spec.resources'"),
+			})),
 	)
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If the shoot manifest has no section `spec.resources`, the validating admission webhook should not silently ignore that  DNS provider secrets must be specified in the resources section.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user bugfix
Don't skip validation for missing provider secret resources if `spec.resources` is undefined in shoot manifest
```
