### PR TITLE
Fix regression bug "secret name is not defined as named resource references at 'spec.resources'"

### DIFF
--- a/pkg/admission/validator/shoot_validator.go
+++ b/pkg/admission/validator/shoot_validator.go
@@ -54,7 +54,7 @@ func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
 
 	allErrs := field.ErrorList{}
 	if dnsConfig != nil {
-		allErrs = append(allErrs, validation.ValidateDNSConfig(dnsConfig, shoot.Spec.Resources)...)
+		allErrs = append(allErrs, validation.ValidateDNSConfig(dnsConfig, &shoot.Spec.Resources)...)
 	}
 
 	return allErrs.ToAggregate()

--- a/pkg/apis/service/validation/validation.go
+++ b/pkg/apis/service/validation/validation.go
@@ -29,8 +29,8 @@ var supportedProviderTypes = []string{
 }
 
 // ValidateDNSConfig validates the passed DNSConfig.
-// if resources != nil, it also validates if the referenced secrets are defined.
-func ValidateDNSConfig(config *service.DNSConfig, resources []core.NamedResourceReference) field.ErrorList {
+// If resources != nil, it also validates if the referenced secrets are defined.
+func ValidateDNSConfig(config *service.DNSConfig, resources *[]core.NamedResourceReference) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(config.Providers) > 0 {
@@ -39,7 +39,7 @@ func ValidateDNSConfig(config *service.DNSConfig, resources []core.NamedResource
 	return allErrs
 }
 
-func validateProviders(providers []service.DNSProvider, resources []core.NamedResourceReference) field.ErrorList {
+func validateProviders(providers []service.DNSProvider, presources *[]core.NamedResourceReference) field.ErrorList {
 	allErrs := field.ErrorList{}
 	path := field.NewPath("spec", "extensions", "[@.type='"+service2.ExtensionType+"']", "providerConfig")
 	for i, p := range providers {
@@ -51,9 +51,9 @@ func validateProviders(providers []service.DNSProvider, resources []core.NamedRe
 		}
 		if p.SecretName == nil || *p.SecretName == "" {
 			allErrs = append(allErrs, field.Required(path.Index(i).Child("secretName"), "secret name is required"))
-		} else {
+		} else if presources != nil {
 			found := false
-			for _, ref := range resources {
+			for _, ref := range *presources {
 				if ref.Name == *p.SecretName {
 					found = true
 					break


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
A regression bug was introduced with #320. The validation method is used at two different places and is used within the extension without checking the resources array.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Already fixed on with Commit https://github.com/gardener/gardener-extension-shoot-dns-service/commit/43c1957eef458cfb2cb3410aad32cfb09945e60a on v1.47-release branch.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix regression bug "secret name is not defined as named resource references at 'spec.resources'" introduced with #320
```
