### PR TITLE
Add appropriate error code for error `duplicate zones [...]`

### DIFF
--- a/pkg/apis/helper/error_codes.go
+++ b/pkg/apis/helper/error_codes.go
@@ -15,7 +15,7 @@ var (
 	unauthorizedRegexp       = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|SignatureDoesNotMatch|AuthorizationFailed|invalid_grant|Authorization Profile was not found|no active subscriptions|UnauthorizedOperation|not authorized|AccessDenied|OperationNotAllowed|Error 403|SERVICE_ACCOUNT_ACCESS_DENIED)`)
 	quotaExceededRegexp      = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded|Quotas|Quota.*exceeded|exceeded quota|Quota has been met|QUOTA_EXCEEDED|Maximum number of ports exceeded|ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS)`)
 	rateLimitsExceededRegexp = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling|Too many requests)`)
-	configurationRegexp      = regexp.MustCompile("(?i)(no domain matching hosting zones)")
+	configurationRegexp      = regexp.MustCompile("(?i)(no domain matching hosting zones|duplicate zones)")
 
 	// KnownCodes maps Gardener error codes to respective regex.
 	KnownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{

--- a/pkg/controller/lifecycle/dnsprovider_test.go
+++ b/pkg/controller/lifecycle/dnsprovider_test.go
@@ -6,11 +6,14 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -232,6 +235,11 @@ var _ = Describe("#DNSProvider", func() {
 
 			err := defaultDepWaiter.Wait(ctx)
 			Expect(err.Error()).To(Equal("Error while waiting for DNSProvider test-chart-namespace/test-deploy to become ready: state Error: duplicate zones X and Y"))
+			var coder helper.Coder
+			Expect(errors.As(err, &coder)).To(BeTrue())
+			Expect(coder.Codes()).To(Equal([]gardencorev1beta1.ErrorCode{
+				"ERR_CONFIGURATION_PROBLEM",
+			}))
 		})
 
 		It("should return error if we haven't observed the latest timestamp annotation", func() {

--- a/pkg/controller/lifecycle/dnsprovider_test.go
+++ b/pkg/controller/lifecycle/dnsprovider_test.go
@@ -224,6 +224,16 @@ var _ = Describe("#DNSProvider", func() {
 			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred())
 		})
 
+		It("should return Coder when error contains error code", func() {
+			expected.Status.State = "Error"
+			expected.Status.Message = ptr.To("duplicate zones X and Y")
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing emptyProvider succeeds")
+
+			err := defaultDepWaiter.Wait(ctx)
+			Expect(err.Error()).To(Equal("Error while waiting for DNSProvider test-chart-namespace/test-deploy to become ready: state Error: duplicate zones X and Y"))
+		})
+
 		It("should return error if we haven't observed the latest timestamp annotation", func() {
 			By("deploy")
 			// Deploy should fill internal state with the added timestamp annotation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR provides the enhancement proposed by the issue below

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-dns-service/issues/329

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Errors like `duplicate zones [...]` will be classified as user errors of type `ERR_CONFIGURATION_PROBLEM`
```
