### PR TITLE
Vertical scaling on CPU dropped in VPA resource

### DIFF
--- a/charts/internal/shoot-dns-service-seed/templates/vpa.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/vpa.yaml
@@ -9,6 +9,7 @@ spec:
     containerPolicies:
       - containerName: '*'
         controlledValues: RequestsOnly
+        controlledResources: [memory]
         minAllowed:
           memory: {{ .Values.vpa.minAllowed.memory }}
   targetRef:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
Using VPA for sudden CPU spikes while the component is mostly dormant causes needless disruptions and wastes resources twofold: VPA has a minimum slice/resolution of 10m/10M, so it cannot recommend any value below 10m CPU even if this component consumes only 1m on average and 2m in the 95th percentile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Vertical scaling on CPU dropped in VPA resource
```
