### PR TITLE
Save entry list compressed in extension state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: test
-test:
+test: $(GINKGO)
 	@bash $(GARDENER_HACK_DIR)/test.sh ./cmd/... ./pkg/...
 
 .PHONY: test-cov
@@ -135,8 +135,12 @@ test-cov:
 test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
+.PHONY: test-integration-lifecycle
+test-integration-lifecycle: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
+	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/lifecycle/...
+
 .PHONY: verify
-verify: check format test sast
+verify: check format test test-integration-lifecycle sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test-cov test-clean sast-report
+verify-extended: check-generate check format test-cov test-clean test-integration-lifecycle sast-report

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20241014194617-ffc4efda75d4
+	github.com/andybalholm/brotli v1.1.1
 	github.com/gardener/external-dns-management v0.22.2
 	github.com/gardener/gardener v1.110.0
 	github.com/go-logr/logr v1.4.2
@@ -29,7 +30,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
-	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/pkg/apis/helper/scheme.go
+++ b/pkg/apis/helper/scheme.go
@@ -5,37 +5,18 @@
 package helper
 
 import (
-	"fmt"
-
-	extapi "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	api "github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis"
 	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/apis/install"
 )
 
 var (
 	// Scheme is a scheme with the types relevant for vSphere actuators.
 	Scheme *runtime.Scheme
-
-	decoder runtime.Decoder
 )
 
 func init() {
 	Scheme = runtime.NewScheme()
 	utilruntime.Must(install.AddToScheme(Scheme))
-
-	decoder = serializer.NewCodecFactory(Scheme).UniversalDecoder()
-}
-
-func GetExtensionState(ext *extapi.Extension) (*api.DNSState, error) {
-	state := &api.DNSState{}
-	if ext.Status.State != nil && ext.Status.State.Raw != nil {
-		if _, _, err := decoder.Decode(ext.Status.State.Raw, nil, state); err != nil {
-			return state, fmt.Errorf("could not decode extension state: %w", err)
-		}
-	}
-	return state, nil
 }

--- a/pkg/controller/common/compressedstate.go
+++ b/pkg/controller/common/compressedstate.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/andybalholm/brotli"
+)
+
+type compressedEntriesState struct {
+	CompressedState []byte `json:"compressedState"`
+}
+
+// CompressEntriesState compresses the entries state data.
+func CompressEntriesState(state []byte) ([]byte, error) {
+	if len(state) == 0 || string(state) == "{}" {
+		return nil, nil
+	}
+
+	var stateCompressed bytes.Buffer
+	writer := brotli.NewWriter(&stateCompressed)
+	defer writer.Close()
+
+	if _, err := writer.Write(state); err != nil {
+		return nil, fmt.Errorf("failed writing entries state data for compression: %w", err)
+	}
+
+	// Close ensures any unwritten data is flushed. Without this, the `stateCompressed`
+	// buffer would not contain any data. Hence, we have to call it explicitly here after writing, in addition to the
+	// 'defer' call above.
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed closing the brotli writer after compressing the entries state data: %w", err)
+	}
+
+	return json.Marshal(&compressedEntriesState{CompressedState: stateCompressed.Bytes()})
+}
+
+// LooksLikeCompressedEntriesState checks if the given state data has the string compressedState in the first 20 bytes.
+func LooksLikeCompressedEntriesState(state []byte) bool {
+	if len(state) < len("compressedState") {
+		return false
+	}
+
+	return bytes.Contains(state[:min(20, len(state))], []byte("compressedState"))
+}
+
+// DecompressEntriesState decompresses the entries state data.
+func DecompressEntriesState(stateCompressed []byte) ([]byte, error) {
+	if len(stateCompressed) == 0 {
+		return nil, nil
+	}
+
+	var entriesState compressedEntriesState
+	if err := json.Unmarshal(stateCompressed, &entriesState); err != nil {
+		return nil, fmt.Errorf("failed unmarshalling JSON to compressed entries state structure: %w", err)
+	}
+
+	reader := brotli.NewReader(bytes.NewReader(entriesState.CompressedState))
+	var state bytes.Buffer
+	if _, err := state.ReadFrom(reader); err != nil {
+		return nil, fmt.Errorf("failed reading machine state data for decompression: %w", err)
+	}
+
+	return state.Bytes(), nil
+}

--- a/pkg/controller/common/compressedstate_test.go
+++ b/pkg/controller/common/compressedstate_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CompressedState", func() {
+	It("should compress and decompress", func() {
+		state := []byte(`{"entries":[{"name":"entry1","spec":{}},{"name":"entry2","spec":{}}]}`)
+		data, err := CompressEntriesState(state)
+		Expect(err).To(BeNil())
+		Expect(data).NotTo(BeNil())
+
+		state2, err := DecompressEntriesState(data)
+		Expect(err).To(BeNil())
+		Expect(state2).NotTo(BeNil())
+		Expect(state).To(Equal(state2))
+	})
+
+	It("should recognise compressed state data by heuristic", func() {
+		state := []byte(`{"entries":[{"name":"entry1","spec":{}},{"name":"entry2","spec":{}}]}`)
+		data, err := CompressEntriesState(state)
+		Expect(err).To(BeNil())
+		Expect(data).NotTo(BeNil())
+
+		Expect(LooksLikeCompressedEntriesState(data)).To(BeTrue())
+		Expect(LooksLikeCompressedEntriesState(state)).To(BeFalse())
+	})
+})

--- a/pkg/controller/common/state.go
+++ b/pkg/controller/common/state.go
@@ -121,17 +121,6 @@ func (s *StateHandler) Refresh() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	/*
-		list = append(list, dnsapi.DNSEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "DUMMY",
-			},
-			Spec: dnsapi.DNSEntrySpec{
-				DNSName: "bla.blub.de",
-				Targets: []string{"8.8.8.8"},
-			},
-		})
-	*/
 	return s.EnsureEntries(list), nil
 }
 
@@ -206,7 +195,7 @@ func (s *StateHandler) Update(reason string) error {
 		wire.Kind = wireapi.DNSStateKind
 		err := helper.Scheme.Convert(s.state, wire, nil)
 		if err != nil {
-			s.Infof("state conversion failed: %s", err)
+			s.Error(err, "state conversion failed")
 			return err
 		}
 		if s.ext.Status.State == nil {
@@ -214,22 +203,21 @@ func (s *StateHandler) Update(reason string) error {
 		}
 		data, err := json.Marshal(wire)
 		if err != nil {
-			s.Info("marshalling failed", "error", err)
+			s.Error(err, "marshalling failed")
 			return err
 		}
 		s.ext.Status.State.Raw, err = CompressEntriesState(data)
 		if err != nil {
-			s.Info("compressing failed", "error", err)
+			s.Error(err, "compressing failed")
 			return err
 		}
 		s.ext.Status.State.Object = nil
 		err = s.client.Status().Update(s.ctx, s.ext)
 		if err != nil {
-			s.Info("update failed", "error", err)
-		} else {
-			s.modified = false
+			s.Error(err, "update failed")
+			return err
 		}
-		return err
+		s.modified = false
 	}
 	return nil
 }

--- a/test/integration/lifecycle/lifecycle_suite_test.go
+++ b/test/integration/lifecycle/lifecycle_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lifecycle Suite")
+}

--- a/test/integration/lifecycle/state_test.go
+++ b/test/integration/lifecycle/state_test.go
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"time"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test"
+	"github.com/gardener/gardener/test/framework"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/common"
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/config"
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/lifecycle"
+)
+
+var (
+	entryCount = flag.Int("entries", 10, "Number of DNS entries to create")
+	logLevel   = flag.String("logLevel", "", "Log level (debug, info, error)")
+)
+
+const (
+	defaultTimeout = 30 * time.Second
+)
+
+func validateFlags() {
+	if len(*logLevel) == 0 {
+		logLevel = ptr.To(logger.DebugLevel)
+	} else {
+		if !slices.Contains(logger.AllLogLevels, *logLevel) {
+			panic("invalid log level: " + *logLevel)
+		}
+	}
+	if *entryCount < 1 {
+		panic("invalid entry count: " + fmt.Sprint(*entryCount))
+	}
+}
+
+var (
+	ctx = context.Background()
+
+	log       logr.Logger
+	testEnv   *envtest.Environment
+	mgrCancel context.CancelFunc
+	c         client.Client
+
+	testName string
+
+	namespace *corev1.Namespace
+	entries   []*dnsv1alpha1.DNSEntry
+	shoot     *gardencorev1beta1.Shoot
+	cluster   *extensionsv1alpha1.Cluster
+)
+
+var _ = BeforeSuite(func() {
+	flag.Parse()
+	validateFlags()
+
+	repoRoot := filepath.Join("..", "..", "..")
+
+	// enable manager logs
+	logf.SetLogger(logger.MustNewZapLogger(*logLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+
+	log = logf.Log.WithName("lifecycle-test")
+
+	config.DNSService.SeedID = "test-seed"
+	config.DNSService.ManageDNSProviders = true
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+
+		By("running cleanup actions")
+		framework.RunCleanupActions()
+
+		By("tearing down shoot environment")
+		teardownShootEnvironment(ctx, c, namespace, entries, cluster)
+
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+		config.DNSService.SeedID = ""
+		config.DNSService.ManageDNSProviders = false
+	})
+
+	By("generating randomized test resource identifiers")
+	testName = fmt.Sprintf("shoot--foo--%s", randomString())
+	namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testName,
+		},
+	}
+	shoot = &gardencorev1beta1.Shoot{
+		Spec: gardencorev1beta1.ShootSpec{
+			DNS: &gardencorev1beta1.DNS{
+				Domain: ptr.To(testName + "example.com"),
+			},
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: "1.31.0",
+			},
+		},
+		Status: gardencorev1beta1.ShootStatus{
+			ClusterIdentity: ptr.To(testName + "-12345678"),
+		},
+	}
+	cluster = &extensionsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testName,
+		},
+		Spec: extensionsv1alpha1.ClusterSpec{
+			CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
+			Seed:         runtime.RawExtension{Raw: []byte("{}")},
+			Shoot:        runtime.RawExtension{Raw: shootToBytes(shoot)},
+		},
+	}
+	entries = createDNSEntries(*shoot.Status.ClusterIdentity, testName, *entryCount)
+
+	By("starting test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join(repoRoot, "example", "11-resource-manager-crds.yaml"),
+				filepath.Join(repoRoot, "example", "20-crds.yaml"),
+			},
+		},
+	}
+
+	restConfig, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(restConfig).ToNot(BeNil())
+
+	By("setting up manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(extensionsv1alpha1.AddToScheme(mgr.GetScheme())).To(Succeed())
+	Expect(dnsv1alpha1.AddToScheme(mgr.GetScheme())).To(Succeed())
+	Expect(resourcesv1alpha1.AddToScheme(mgr.GetScheme())).To(Succeed())
+
+	Expect(lifecycle.AddToManagerWithOptions(ctx, mgr, lifecycle.AddOptions{})).To(Succeed())
+
+	var mgrContext context.Context
+	mgrContext, mgrCancel = context.WithCancel(ctx)
+
+	By("starting manager")
+	go func() {
+		defer GinkgoRecover()
+		err := mgr.Start(mgrContext)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// test client should be uncached and independent from the tested manager
+	c, err = client.New(restConfig, client.Options{Scheme: mgr.GetScheme()})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c).NotTo(BeNil())
+
+	By("setting up shoot environment")
+	setupShootEnvironment(ctx, c, namespace, entries, cluster)
+})
+
+var _ = Describe("Lifecycle state tests", func() {
+	It("it should update the extension status state", func() {
+		By("creating extension")
+		ext := &extensionsv1alpha1.Extension{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testName,
+			},
+			Spec: extensionsv1alpha1.ExtensionSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: "shoot-dns-service",
+				},
+			},
+		}
+		Expect(c.Create(ctx, ext)).To(Succeed())
+
+		By("wait for 'external' DNSProvider and patch it to Ready")
+		CEventually(ctx, func(g Gomega) error {
+			provider := &dnsv1alpha1.DNSProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testName,
+					Name:      "external",
+				},
+			}
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(provider), provider)).To(Succeed())
+
+			patch := client.MergeFrom(provider.DeepCopy())
+			provider.Status.State = "Ready"
+			provider.Status.LastUptimeTime = &metav1.Time{Time: time.Now()}
+			provider.Status.ObservedGeneration = provider.Generation
+			return c.Status().Patch(ctx, provider, patch)
+		}).Should(Succeed())
+
+		By("waiting for extension last operation to succeed")
+		CEventually(ctx, func() bool {
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(ext), ext)).To(Succeed())
+			return ext.Status.LastOperation != nil && ext.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
+		}).WithPolling(1 * time.Second).WithTimeout(defaultTimeout).Should(BeTrue())
+
+		By("check for managed resources")
+		mr := &resourcesv1alpha1.ManagedResource{}
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: testName, Name: "extension-shoot-dns-service-seed"}, mr)).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: testName, Name: "extension-shoot-dns-service-shoot"}, mr)).To(Succeed())
+
+		By("check compressed extension state")
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(ext), ext)).To(Succeed())
+		Expect(ext.Status.State).NotTo(BeNil())
+		Expect(common.LooksLikeCompressedEntriesState(ext.Status.State.Raw)).Should(BeTrue())
+		compressedSize := len(ext.Status.State.Raw)
+		uncompressed, err := common.DecompressEntriesState(ext.Status.State.Raw)
+		Expect(err).NotTo(HaveOccurred())
+
+		state, err := common.GetExtensionState(ext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).NotTo(BeNil())
+		Expect(state.Entries).To(HaveLen(len(entries)))
+
+		By("check uncompressed extension state")
+		ext.Status.State.Raw = uncompressed
+		state2, err := common.GetExtensionState(ext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state2).NotTo(BeNil())
+		Expect(state).To(Equal(state2))
+
+		log.Info("compressed rate", "rate", fmt.Sprintf("%.1f %%", 100.0*float32(compressedSize)/float32(len(uncompressed))))
+
+		By("deleting extension")
+		Expect(c.Delete(ctx, ext)).To(Succeed())
+		CEventually(ctx, func() bool {
+			err := c.Get(ctx, client.ObjectKeyFromObject(ext), ext)
+			return err != nil && client.IgnoreNotFound(err) == nil
+		}).WithPolling(1 * time.Second).WithTimeout(defaultTimeout).Should(BeTrue())
+	})
+})
+
+func setupShootEnvironment(ctx context.Context, c client.Client, namespace *corev1.Namespace, entries []*dnsv1alpha1.DNSEntry, cluster *extensionsv1alpha1.Cluster) {
+	Expect(c.Create(ctx, namespace)).To(Succeed())
+	for _, entry := range entries {
+		status := *entry.Status.DeepCopy()
+		Expect(c.Create(ctx, entry)).To(Succeed())
+		entry.Status = status
+		entry.Status.ObservedGeneration = entry.Generation
+		Expect(c.SubResource("status").Update(ctx, entry)).To(Succeed())
+	}
+	Expect(c.Create(ctx, cluster)).To(Succeed())
+}
+
+func teardownShootEnvironment(ctx context.Context, c client.Client, namespace *corev1.Namespace, entries []*dnsv1alpha1.DNSEntry, cluster *extensionsv1alpha1.Cluster) {
+	Expect(client.IgnoreNotFound(c.Delete(ctx, cluster))).To(Succeed())
+	for _, entry := range entries {
+		Expect(client.IgnoreNotFound(c.Delete(ctx, entry))).To(Succeed())
+	}
+	Expect(c.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace.Name), client.MatchingLabels{"resources.gardener.cloud/garbage-collectable-reference": "true"})).To(Succeed())
+	Expect(client.IgnoreNotFound(c.Delete(ctx, namespace))).To(Succeed())
+}
+
+func createDNSEntries(shootID, namespace string, count int) []*dnsv1alpha1.DNSEntry {
+	entries := make([]*dnsv1alpha1.DNSEntry, count)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("dnsentry-%d", i)
+		entries[i] = &dnsv1alpha1.DNSEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					common.ShootDNSEntryLabelKey: shootID,
+				},
+			},
+			Spec: dnsv1alpha1.DNSEntrySpec{
+				DNSName: name + "some.blabla.example.com",
+				OwnerId: ptr.To("shoot--foo--barbar-e5421aeb-a317-3f25-afbc-f0e12fce61bd-test-landscape-shootdns"),
+				TTL:     ptr.To[int64](300),
+			},
+			Status: dnsv1alpha1.DNSEntryStatus{
+				Provider:       ptr.To("shoot--foo--barbar/some-test-provider"),
+				LastUptimeTime: ptr.To(metav1.Now()),
+				ProviderType:   ptr.To("aws-route53"),
+				State:          "Ready",
+				Targets:        []string{fmt.Sprintf("f00aa479c3011153f4bdd5f65b89e7ff-f000-%04x.elb.eu-central-1.amazonaws.com", i)},
+				TTL:            ptr.To[int64](300),
+				Zone:           ptr.To("ZFOOBAR4ROWB4VQ"),
+			},
+		}
+	}
+	return entries
+}
+
+func randomString() string {
+	rs, err := gardenerutils.GenerateRandomStringFromCharset(5, "0123456789abcdefghijklmnopqrstuvwxyz")
+	Expect(err).NotTo(HaveOccurred())
+	return rs
+}
+
+func shootToBytes(shoot *gardencorev1beta1.Shoot) []byte {
+	data, err := json.Marshal(shoot)
+	Expect(err).NotTo(HaveOccurred())
+	return data
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
The `DNSEntries` of the shoot must be stored in the `.status.state` of the `Extension` resource for resurrection after control plane migration.
If a shoot has about 2000 entries, this state becomes so big, that the request size limit of etcd (1.5MB) is hit (`etcdserver: request is too large`).
To shift the maximum number of DNS entries which can be supported, the state is now compressed with the `brotli` algorithm. We expect to see compression ratios >= 6, so the limit should now be beyond 10,000 entries.

**Which issue(s) this PR fixes**:
Fixes #413 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The entry list stored in the extension resource status is now compressed to shift the limit before hitting the request size limit of etcd. 
```
