### PR TITLE
feat: Add support for switching the `dns-controller-manager` image

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -1,4 +1,8 @@
 images:
+- name: dns-controller-manager-with-metadata-records # TODO(marc1404): Remove once metadata records have been cleaned up.
+  sourceRepository: github.com/gardener/external-dns-management
+  repository: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
+  tag: "v0.22.2" # needs to stay < v0.23.0
 - name: dns-controller-manager
   sourceRepository: github.com/gardener/external-dns-management
   repository: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind task

**What this PR does / why we need it**:

This PR adds support for switching the image to be used for the `dns-controller-manager` deployment.
It adds a secondary entry in the `imagevector.yaml` that allows referencing a different version of the `dns-controller-manager` image.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for switching the `dns-controller-manager` image.
```
