### PR TITLE
feat: Build `linux/arm64` image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -46,6 +46,10 @@ gardener-extension-shoot-dns-service:
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           gardener-extension-shoot-dns-service:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/shoot-dns-service


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

This PR introduces a multi-arch build for the Docker image to publish a `linux/arm64` image.
Currently, it's not possible to use the `extension-shoot-dns-service` on `arm64` machines.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduce multi-arch build for `linux/arm64` images.
```
