### PR TITLE
docs: Document `AAAA` DNS records for dual-stack load balancers on AWS

### DIFF
--- a/docs/usage/dns_names.md
+++ b/docs/usage/dns_names.md
@@ -71,6 +71,8 @@ metadata:
     dns.gardener.cloud/class: garden
     # If you are delegating the certificate management to Gardener, uncomment the following line
     #cert.gardener.cloud/purpose: managed
+    # If you're using a load balancer on AWS and expect the creation of both `A` and `AAAA` records, uncomment the following line
+    #dns.gardener.cloud/ip-stack: dual-stack
 spec:
   rules:
   - host: special.example.com
@@ -107,6 +109,8 @@ metadata:
     dns.gardener.cloud/dnsnames: special.example.com
     dns.gardener.cloud/ttl: "600"
     dns.gardener.cloud/class: garden
+    # If you're using a load balancer on AWS and expect the creation of both `A` and `AAAA` records, uncomment the following line
+    #dns.gardener.cloud/ip-stack: dual-stack
 spec:
   selector:
     app: amazing-app
@@ -116,6 +120,19 @@ spec:
       targetPort: 8080
   type: LoadBalancer
 ```
+
+### Request `AAAA` DNS records for Dual-Stack load balancers on AWS
+
+For Amazon Route 53 and AWS load balancers, `A` DNS records with alias target are created instead of `CNAME` as an optimization.
+
+To support dual-stack IP addresses in this case, set one of these annotations:
+
+* `service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack` (`Service` only)
+* `dns.gardener.cloud/ip-stack=dual-stack` (`Ingress`, `Service`, or `DNSEntry`)
+
+In this case, both `A` and `AAAA` records with alias target records are created.
+
+With the annotation `dns.gardener.cloud/ip-stack=ipv6`, only an `AAAA` record with alias target is created.
 
 ### Request DNS records for Gateway resources
 

--- a/example/40-shoot-source-service.yaml
+++ b/example/40-shoot-source-service.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: dummy.xxx.ondemand.com
+    # If you're using a load balancer on AWS and expect the creation of both `A` and `AAAA` records, uncomment the following line
+    #dns.gardener.cloud/ip-stack: dual-stack
   name: dummy-service
   namespace: default
 spec:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation usability
/kind task enhancement

**What this PR does / why we need it**:

This PR adds a new section to the usage documentation that highlights the need for setting an annotation for dual-stack AWS load balancers so that `AAAA` DNS records are created.
It reuses and adapts the section already present in the README of the `external-dns-management` controller:
https://github.com/gardener/external-dns-management#a-dns-records-with-alias-targets-for-provider-type-aws-route53-and-aws-load-balancers

The goal is to make this caveat more visible on the following page:
https://gardener.cloud/docs/extensions/others/gardener-extension-shoot-dns-service/dns_names/

**Which issue(s) this PR fixes**:

Fixes [#584](https://github.com/gardener/external-dns-management/issues/584)

**Special notes for your reviewer**:

/cc @ScheererJ @MartinWeindel 

I'm unsure where to best place this section or whether it should be part of the respective `Ingress` / `Service` sections.
I decided to add it right below them. I felt like placing it further down the page would decrease visibility, even when it's specific to dual-stack load balancers on AWS and using Amazon Route 53 as the DNS provider.
Happy to hear your thoughts :) 💭 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Documented requesting the creation of `AAAA` DNS records when using dual-stack load balancers on AWS.
```
