### PR TITLE
Fix `Create Upgrade-Pull-Requests` workflow

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -8,5 +8,5 @@ cp "$(dirname $0)"/../imagevector/images.yaml "$(dirname $0)"/../charts/images.y
 
 "$(dirname $0)"/../hack/.ci/set_dependency_version_dnsman
 
-## need to update example/controller-registration.yaml
+## need to update generated examples
 make -C "$(dirname $0)"/.. generate

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -9,16 +9,4 @@ cp "$(dirname $0)"/../imagevector/images.yaml "$(dirname $0)"/../charts/images.y
 "$(dirname $0)"/../hack/.ci/set_dependency_version_dnsman
 
 ## need to update example/controller-registration.yaml
-## as 'make generate' is not possible easily, we hav some duplicate steps here
-
-# download helm
-curl -sSfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | HELM_INSTALL_DIR=/tmp USE_SUDO=false VERIFY_CHECKSUM=false bash -s -- --version v3.6.3
-export PATH=/tmp:$PATH
-
-# install gnutar
-apk add tar yq
-
-# generate example/controller-registration.yaml
-cd "$(dirname $0)"/../charts/gardener-extension-shoot-dns-service
-"$(dirname $0)"/hack/generate-controller-registration.sh extension-shoot-dns-service . $(cat ../../VERSION) ../../example/controller-registration.yaml Extension:shoot-dns-service
-sed -i 's/ type: shoot-dns-service/ type: shoot-dns-service\n    workerlessSupported: true/' ../../example/controller-registration.yaml
+make -C "$(dirname $0)"/.. generate


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind task

**What this PR does / why we need it**:
The workflow [Create Upgrade-Pull-Requests](https://github.com/gardener/gardener-extension-shoot-dns-service/actions/workflows/upgrade-dependencies.yaml) fails as the base image is now Ubuntu instead of alpine.
This PR tries to run `make generate` to keep it simple. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not sure if it really works.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
