### PR TITLE
Fix admission helm chart OCI repository paths after renaming

### DIFF
--- a/example/extension-shoot-dns-service.yaml
+++ b/example/extension-shoot-dns-service.yaml
@@ -10,11 +10,11 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-runtime:v1.70.0-dev
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-runtime:v1.70.0-dev
       virtualCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-application:v1.70.0-dev
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-application:v1.70.0-dev
     extension:
       helm:
         ociRepository:

--- a/example/shoot-dns-service/base/extension-patch.yaml
+++ b/example/shoot-dns-service/base/extension-patch.yaml
@@ -11,8 +11,8 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: local-skaffold/gardener-extension-shoot-dns-service/charts/admission-shoot-dns-service-runtime:v0.0.0
+            ref: local-skaffold/gardener-extension-shoot-dns-service/charts/shoot-dns-service-admission-runtime:v0.0.0
       virtualCluster:
         helm:
           ociRepository:
-            ref: local-skaffold/gardener-extension-shoot-dns-service/charts/admission-shoot-dns-service-application:v0.0.0
+            ref: local-skaffold/gardener-extension-shoot-dns-service/charts/shoot-dns-service-admission-application:v0.0.0

--- a/example/shoot-dns-service/example/extension-patch.yaml
+++ b/example/shoot-dns-service/example/extension-patch.yaml
@@ -11,11 +11,11 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-runtime:v1.70.0-dev
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-runtime:v1.70.0-dev
       virtualCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-application:v1.70.0-dev
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-application:v1.70.0-dev
     extension:
       helm:
         ociRepository:

--- a/hack/prepare-operator-extension.sh
+++ b/hack/prepare-operator-extension.sh
@@ -22,11 +22,11 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-runtime:$version
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-runtime:$version
       virtualCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-shoot-dns-service-application:$version
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/shoot-dns-service-admission-application:$version
     extension:
       helm:
         ociRepository:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
Fix admission helm chart OCI repository paths after they have been renamed on migration to GHA.

**Which issue(s) this PR fixes**:
Fixes #540 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix admission helm chart OCI repository paths after renaming.
```
