### PR TITLE
[release-v1.71] Replicated providers should not be deleted during extension reconciliation

### DIFF
--- a/pkg/controller/lifecycle/dnsprovider.go
+++ b/pkg/controller/lifecycle/dnsprovider.go
@@ -72,6 +72,7 @@ func (p *provider) Deploy(ctx context.Context) error {
 }
 
 func (p *provider) Destroy(ctx context.Context) error {
+	p.logger.Info("Deleting DNSProvider", "name", p.dnsProvider.Name)
 	return client.IgnoreNotFound(p.client.Delete(ctx, p.dnsProvider))
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
In PR #580 (Handle custom resources on shoot deletion and add E2E test) the method `addCleanupOfOldAdditionalProviders` was extended to delete replicated providers during final cleanup. But this method is also called during normal reconciliation of the extension and there is no logic as for the additional providers to remove non-orphan providers from the delete list later. Therefore the replicated providers are deleted by mistake. As they are recreated within seconds again by the `dnsprovider-replication` controller of the dns-controller-manager running in the control plane, most of the time nothing happens. But in edge cases, this can lead to temporary deletion of the DNS records if a `DNSEntry` has no valid provider anymore for a short period of time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Cherry-picking #607 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Replicated providers should not be deleted during extension reconciliation.
```
