### PR TITLE
Fix local registry for e2e testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ verify-extended: check-generate check format test-cov test-clean test-integratio
 
 .PHONY: extension-up
 extension-up: export EXTENSION_VERSION = $(VERSION)
-extension-up: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
+extension-up: export SKAFFOLD_DEFAULT_REPO = registry.local.gardener.cloud:5001
 extension-up: export SKAFFOLD_PUSH = true
 extension-up: export LD_FLAGS = $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION gardener-extension-shoot-dns-service)
 extension-up: export EXTENSION_GARDENER_HACK_DIR = $(GARDENER_HACK_DIR)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: shoot-dns-service
 build:
   insecureRegistries:
-    - garden.local.gardener.cloud:5001
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: "{{.version}}-{{.sha}}"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
Fix local registry for e2e testing. The registry has been changed recently in gardener/gardener and was not updated at all places.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
