### PR TITLE
Add label for seed to control usage of next-generation controller

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -101,7 +101,11 @@ type extensionContext struct {
 }
 
 func (exCtx *extensionContext) useNextGenerationController() bool {
-	switch exCtx.cluster.Seed.Labels[ShootDNSServiceUseNextGenerationController] {
+	value := ""
+	if exCtx.cluster != nil && exCtx.cluster.Seed != nil {
+		value = exCtx.cluster.Seed.Labels[ShootDNSServiceUseNextGenerationController]
+	}
+	switch value {
 	case "force-true":
 		return true
 	case "force-false":


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The seed label `service.dns.extensions.gardener.cloud/use-next-generation-controller` is considered to decide if the 
next-generation controller should be used.
Possible label values are:
- `true`: default is true if not specified in the provider config field `useNextGenerationController`
- `false` (or not set): default is false
- `force-true`: always true
- `force-false`: always false


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add seed label `service.dns.extensions.gardener.cloud/use-next-generation-controller` to control usage of next-generation controller.
```
