### PR TITLE
Fix updating release version for `dns-controller-manager-next-generation`

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -2,7 +2,8 @@
 
 set -e
 
-"$(dirname $0)"/hack/set_dependency_version
+"$(dirname $0)"/hack/set_dependency_version '{"external-dns-management": ["dns-controller-manager","dns-controller-manager-next-generation"]}'
+
 # update copy in charts directory needed for installation after RBSC sync
 cp "$(dirname $0)"/../imagevector/images.yaml "$(dirname $0)"/../charts/images.yaml
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind task

**What this PR does / why we need it**:
On automatic PRs after releasing external-dns-management, the version for `dns-controller-manager-next-generation` is not updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
