### PR TITLE
Drop support for K8s `<= 1.31`

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/service.yaml
@@ -5,14 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
-    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
-    {{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -21,7 +15,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
-  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
   {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}

--- a/test/integration/lifecycle/state_test.go
+++ b/test/integration/lifecycle/state_test.go
@@ -121,7 +121,7 @@ var _ = BeforeSuite(func() {
 				Domain: new(testName + "example.com"),
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.31.0",
+				Version: "1.32.0",
 			},
 		},
 		Status: gardencorev1beta1.ShootStatus{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
This PR removes the support for Kubernetes versions <= 1.31.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13919

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer supports Kubernetes versions `<= 1.31`. Please make sure to upgrade all Garden, Seed and Shoot clusters to at least version 1.32 before deploying this extension version.
```
