### PR TITLE
Ignore maxquota annotation if quota is disabled; refactor for testability

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -550,7 +550,7 @@ func (a *actuator) createOrUpdateDNSProviders(exCtx extensionContext) error {
 		providers := map[string]*dnsv1alpha1.DNSProvider{}
 		providers[ExternalDNSProviderName] = nil // remember for deletion
 		if external != nil {
-			quota, err := GetDefaultDomainQuota(a.config, exCtx.cluster)
+			quota, err := getDefaultDomainQuota(a.config, exCtx.cluster)
 			if err != nil {
 				return err
 			}
@@ -1168,12 +1168,12 @@ func oneOf(strs ...*string) string {
 	return ""
 }
 
-// GetDefaultDomainQuota calculates the DNS entries quota for the default external provider.
+// getDefaultDomainQuota calculates the DNS entries quota for the default external provider.
 // It returns the configured default quota, which can be overridden via the shoot annotation
 // 'service.dns.extensions.gardener.cloud/default-external-provider-entries-quota'.
 // The annotation value is validated and constrained by DefaultExternalProviderEntriesQuotaMax.
 // Returns 0 if quotas are disabled (DefaultExternalProviderEntriesQuota == 0).
-func GetDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Cluster) (int32, error) {
+func getDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Cluster) (int32, error) {
 	quota := cfg.DefaultExternalProviderEntriesQuota
 	if quota == 0 {
 		return 0, nil // quotas not enabled
@@ -1191,7 +1191,7 @@ func GetDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Clus
 		if maxQuota == 0 {
 			maxQuota = quota // restrict to default quota if no maximum quota is configured via flag, to avoid accidentally setting an unreasonably high quota via annotation
 		}
-		if quota > 0 && parsedQuota > int64(maxQuota) {
+		if parsedQuota > int64(maxQuota) {
 			return 0, fmt.Errorf("annotated default external provider entries quota %d (shoot annotation %s) exceeds maximum allowed quota %d", parsedQuota, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, maxQuota)
 		}
 		quota = int32(parsedQuota)

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -1180,7 +1180,7 @@ func GetDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Clus
 	}
 	// Allow overwriting the default quota up to the maximum quota given by `--default-external-provider-entries-quota-max` via annotation on the shoot, e.g. `service.dns.extensions.gardener.cloud/default-external-provider-entries-quota: "100"`
 	if annotatedValue := cluster.Shoot.Annotations[ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation]; annotatedValue != "" {
-		parsedQuota, err := strconv.Atoi(annotatedValue)
+		parsedQuota, err := strconv.ParseInt(annotatedValue, 10, 32)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse default external provider entries quota %s (shoot annotation %s): %w", annotatedValue, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, err)
 		}
@@ -1191,10 +1191,10 @@ func GetDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Clus
 		if maxQuota == 0 {
 			maxQuota = quota // restrict to default quota if no maximum quota is configured via flag, to avoid accidentally setting an unreasonably high quota via annotation
 		}
-		if quota > 0 && parsedQuota > int(maxQuota) {
+		if quota > 0 && parsedQuota > int64(maxQuota) {
 			return 0, fmt.Errorf("annotated default external provider entries quota %d (shoot annotation %s) exceeds maximum allowed quota %d", parsedQuota, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, maxQuota)
 		}
-		quota = int32(parsedQuota) // #nosec G115 G109 -- safe: parsedQuota <= maxQuota and maxQuota is int32
+		quota = int32(parsedQuota)
 	}
 	return quota, nil
 }

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -550,24 +550,9 @@ func (a *actuator) createOrUpdateDNSProviders(exCtx extensionContext) error {
 		providers := map[string]*dnsv1alpha1.DNSProvider{}
 		providers[ExternalDNSProviderName] = nil // remember for deletion
 		if external != nil {
-			quota := config.DNSService.DefaultExternalProviderEntriesQuota
-			// Allow overwriting the default quota up to the maximum quota given by `--default-external-provider-entries-quota-max` via annotation on the shoot, e.g. `service.dns.extensions.gardener.cloud/default-external-provider-entries-quota: "100"`
-			if annotatedValue := exCtx.cluster.Shoot.Annotations[ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation]; annotatedValue != "" {
-				parsedQuota, err := strconv.Atoi(annotatedValue)
-				if err != nil {
-					return fmt.Errorf("failed to parse default external provider entries quota %s (shoot annotation %s): %w", annotatedValue, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, err)
-				}
-				if parsedQuota < 1 {
-					return fmt.Errorf("invalid default external provider entries quota %s (shoot annotation %s)", annotatedValue, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation)
-				}
-				maxQuota := a.config.DefaultExternalProviderEntriesQuotaMax
-				if maxQuota == 0 {
-					maxQuota = quota // restrict to default quota if no maximum quota is configured via flag, to avoid accidentally setting an unreasonably high quota via annotation
-				}
-				if parsedQuota > int(maxQuota) {
-					return fmt.Errorf("annotated default external provider entries quota %d (shoot annotation %s) exceeds maximum allowed quota %d", parsedQuota, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, maxQuota)
-				}
-				quota = int32(parsedQuota) // #nosec G115 G109 -- safe: parsedQuota <= maxQuota and maxQuota is int32
+			quota, err := GetDefaultDomainQuota(a.config, exCtx.cluster)
+			if err != nil {
+				return err
 			}
 			providers[ExternalDNSProviderName] = buildDNSProviderWithQuota(external, namespace, ExternalDNSProviderName, "", quota)
 		}
@@ -1181,4 +1166,35 @@ func oneOf(strs ...*string) string {
 		}
 	}
 	return ""
+}
+
+// GetDefaultDomainQuota calculates the DNS entries quota for the default external provider.
+// It returns the configured default quota, which can be overridden via the shoot annotation
+// 'service.dns.extensions.gardener.cloud/default-external-provider-entries-quota'.
+// The annotation value is validated and constrained by DefaultExternalProviderEntriesQuotaMax.
+// Returns 0 if quotas are disabled (DefaultExternalProviderEntriesQuota == 0).
+func GetDefaultDomainQuota(cfg config.DNSServiceConfig, cluster *controller.Cluster) (int32, error) {
+	quota := cfg.DefaultExternalProviderEntriesQuota
+	if quota == 0 {
+		return 0, nil // quotas not enabled
+	}
+	// Allow overwriting the default quota up to the maximum quota given by `--default-external-provider-entries-quota-max` via annotation on the shoot, e.g. `service.dns.extensions.gardener.cloud/default-external-provider-entries-quota: "100"`
+	if annotatedValue := cluster.Shoot.Annotations[ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation]; annotatedValue != "" {
+		parsedQuota, err := strconv.Atoi(annotatedValue)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse default external provider entries quota %s (shoot annotation %s): %w", annotatedValue, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, err)
+		}
+		if parsedQuota < 1 {
+			return 0, fmt.Errorf("invalid default external provider entries quota %s (shoot annotation %s)", annotatedValue, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation)
+		}
+		maxQuota := cfg.DefaultExternalProviderEntriesQuotaMax
+		if maxQuota == 0 {
+			maxQuota = quota // restrict to default quota if no maximum quota is configured via flag, to avoid accidentally setting an unreasonably high quota via annotation
+		}
+		if quota > 0 && parsedQuota > int(maxQuota) {
+			return 0, fmt.Errorf("annotated default external provider entries quota %d (shoot annotation %s) exceeds maximum allowed quota %d", parsedQuota, ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation, maxQuota)
+		}
+		quota = int32(parsedQuota) // #nosec G115 G109 -- safe: parsedQuota <= maxQuota and maxQuota is int32
+	}
+	return quota, nil
 }

--- a/pkg/controller/lifecycle/actuator_quota_test.go
+++ b/pkg/controller/lifecycle/actuator_quota_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ import (
 	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/config"
 )
 
-var _ = Describe("GetDefaultDomainQuota", func() {
+var _ = Describe("getDefaultDomainQuota", func() {
 	DescribeTable("should return correct quota",
 		func(defaultQuota, maxQuota int32, annotation *string, expectedQuota int32, expectError bool, errorSubstring string) {
 			// Set up config
@@ -40,7 +40,7 @@ var _ = Describe("GetDefaultDomainQuota", func() {
 			}
 
 			// Call function
-			quota, err := GetDefaultDomainQuota(cfg, cluster)
+			quota, err := getDefaultDomainQuota(cfg, cluster)
 
 			// Verify results
 			if expectError {

--- a/pkg/controller/lifecycle/actuator_quota_test.go
+++ b/pkg/controller/lifecycle/actuator_quota_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle
+
+import (
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener-extension-shoot-dns-service/pkg/controller/config"
+)
+
+var _ = Describe("GetDefaultDomainQuota", func() {
+	DescribeTable("should return correct quota",
+		func(defaultQuota, maxQuota int32, annotation *string, expectedQuota int32, expectError bool, errorSubstring string) {
+			// Set up config
+			cfg := config.DNSServiceConfig{
+				DefaultExternalProviderEntriesQuota:    defaultQuota,
+				DefaultExternalProviderEntriesQuotaMax: maxQuota,
+			}
+
+			// Create cluster with optional annotation
+			cluster := &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-shoot",
+						Namespace: "garden-test",
+					},
+				},
+			}
+
+			if annotation != nil {
+				cluster.Shoot.Annotations = map[string]string{
+					ShootDNSServiceDefaultExternalProviderEntriesQuotaAnnotation: *annotation,
+				}
+			}
+
+			// Call function
+			quota, err := GetDefaultDomainQuota(cfg, cluster)
+
+			// Verify results
+			if expectError {
+				Expect(err).To(HaveOccurred())
+				if errorSubstring != "" {
+					Expect(err.Error()).To(ContainSubstring(errorSubstring))
+				}
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(quota).To(Equal(expectedQuota))
+			}
+		},
+		Entry("quotas disabled - no annotation", int32(0), int32(0), nil, int32(0), false, ""),
+		Entry("quotas disabled - with annotation", int32(0), int32(0), new("50"), int32(0), false, ""),
+		Entry("default quota - no annotation", int32(100), int32(0), nil, int32(100), false, ""),
+		Entry("default quota - with valid annotation within default", int32(100), int32(0), new("80"), int32(80), false, ""),
+		Entry("default quota - with valid annotation exceeding default without max", int32(100), int32(0), new("150"), int32(0), true, "exceeds maximum allowed quota 100"),
+		Entry("default quota with max - valid annotation within max", int32(100), int32(200), new("150"), int32(150), false, ""),
+		Entry("default quota with max - annotation equals max", int32(100), int32(200), new("200"), int32(200), false, ""),
+		Entry("default quota with max - annotation exceeds max", int32(100), int32(200), new("250"), int32(0), true, "exceeds maximum allowed quota 200"),
+		Entry("annotation with invalid format", int32(100), int32(0), new("invalid"), int32(0), true, "failed to parse"),
+		Entry("annotation with negative value", int32(100), int32(0), new("-10"), int32(0), true, "invalid default external provider entries quota"),
+		Entry("annotation with zero value", int32(100), int32(0), new("0"), int32(0), true, "invalid default external provider entries quota"),
+		Entry("annotation with empty string - returns default", int32(100), int32(0), new(""), int32(100), false, ""),
+		Entry("small default quota - annotation within limit", int32(10), int32(0), new("5"), int32(5), false, ""),
+		Entry("small default quota - annotation exceeds limit", int32(10), int32(0), new("15"), int32(0), true, "exceeds maximum allowed quota 10"),
+	)
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This is mainly a refactoring with a minor fix for an edge case: If quota is disabled, the annotation `service.dns.extensions.gardener.cloud/default-external-provider-entries-quota` is ignored now.

  Refactor: Extract and test DNS quota calculation logic

  Extracts the DNS default domain quota calculation from createOrUpdateDNSProviders into a standalone GetDefaultDomainQuota function with comprehensive test coverage.

  Changes:
  - Extracted quota calculation logic into testable function
  - Added 14 test cases using DescribeTable covering all scenarios (happy paths, edge cases, validation)
  - No functional changes - pure refactoring     
       
  Why: 
  - Improves code testability and maintainability
  - Provides clear unit tests for quota validation logic
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
follow-up of #690 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
