### PR TITLE
Clean up `gardener.virtualCluster.enabled` setting from admission charts

### DIFF
--- a/charts/gardener-extension-admission-shoot-dns-service/charts/application/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/application/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gardener.virtualCluster.enabled ( not .Values.gardener.virtualCluster.serviceAccount.name ) }}
+{{- if not .Values.gardener.virtualCluster.serviceAccount.name }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/gardener-extension-admission-shoot-dns-service/charts/application/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/application/values.yaml
@@ -1,6 +1,5 @@
 gardener:
   virtualCluster:
-    enabled: true
     serviceAccount: {}
 #     name: gardener-extension-admission-shoot-dns-service
 #     namespace: kube-system

--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/templates/deployment.yaml
@@ -37,12 +37,8 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
-        {{- if .Values.gardener.virtualCluster.enabled }}
         - --webhook-config-mode=url
         - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}
-        {{- else }}
-        - --webhook-config-mode=service
-        {{- end}}
         - --webhook-config-namespace={{ .Release.Namespace }}
         {{- if .Values.gardener.virtualCluster.namespace }}
         - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
@@ -66,10 +62,6 @@ spec:
         {{- end }}
         {{- end }}
         env:
-        {{- if .Values.gardener.virtualCluster.enabled }}
-        - name: SOURCE_CLUSTER
-          value: enabled
-        {{- end }}
         {{- if not .Values.validateSecrets }}
         - name: DISABLE_SECRET_VALIDATION
           value: "true"

--- a/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-shoot-dns-service/charts/runtime/values.yaml
@@ -33,11 +33,8 @@ service:
 validateSecrets: true
 
 gardener:
-  virtualCluster:
-    enabled: true
-    serviceAccount: {}
-#     name: ardener-extension-admission-shoot-dns-service
-#     namespace: kube-system
+  virtualCluster: {}
+#   namespace: extension-admission-shoot-dns-service
   runtimeCluster: {}
 #   priorityClassName: gardener-garden-system-400
 

--- a/cmd/gardener-extension-admission-shoot-dns-service/app/app.go
+++ b/cmd/gardener-extension-admission-shoot-dns-service/app/app.go
@@ -17,14 +17,11 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -106,29 +103,12 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not complete admission options")
 			}
 
-			// Operators can enable the source cluster option via SOURCE_CLUSTER environment variable.
-			// In-cluster config will be used if no SOURCE_KUBECONFIG is specified.
-			//
-			// The source cluster is for instance used by Gardener's certificate controller, to maintain certificate
-			// secrets in a different cluster ('runtime-garden') than the cluster where the webhook configurations
-			// are maintained ('virtual-garden').
-			var sourceClusterConfig *rest.Config
-			if sourceClusterEnabled := os.Getenv("SOURCE_CLUSTER"); sourceClusterEnabled != "" {
-				log.Info("Configuring source cluster option")
-				var err error
-				sourceClusterConfig, err = clientcmd.BuildConfigFromFlags("", os.Getenv("SOURCE_KUBECONFIG"))
-				if err != nil {
-					return err
-				}
-				managerOptions.LeaderElectionConfig = sourceClusterConfig
-			} else {
-				// Restrict the cache for secrets to the configured namespace to avoid the need for cluster-wide list/watch permissions.
-				managerOptions.Cache = cache.Options{
-					ByObject: map[client.Object]cache.ByObject{
-						&corev1.Secret{}: {Namespaces: map[string]cache.Config{webhookOptions.Server.Completed().Namespace: {}}},
-					},
-				}
+			log.Info("Configuring source cluster option")
+			inClusterConfig, err := rest.InClusterConfig()
+			if err != nil {
+				return fmt.Errorf("could not get in-cluster config: %w", err)
 			}
+			managerOptions.LeaderElectionConfig = inClusterConfig
 
 			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
 			if err != nil {
@@ -147,23 +127,20 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				os.Exit(1)
 			}
 
-			var sourceCluster cluster.Cluster
-			if sourceClusterConfig != nil {
-				sourceCluster, err = cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
-					opts.Logger = log
-					opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
-				})
-				if err != nil {
-					return err
-				}
+			sourceCluster, err := cluster.New(inClusterConfig, func(opts *cluster.Options) {
+				opts.Logger = log
+				opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
+			})
+			if err != nil {
+				return err
+			}
 
-				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
-					return err
-				}
+			if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
+				return err
+			}
 
-				if err = mgr.Add(sourceCluster); err != nil {
-					return err
-				}
+			if err = mgr.Add(sourceCluster); err != nil {
+				return err
 			}
 
 			log.Info("Setting up webhook server")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Clean up `gardener.virtualCluster.enabled` setting from admission charts.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-registry-cache/pull/581

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Deploying the shoot-dns-service admission in a setup where the virtual cluster is NOT enabled is no longer supported. The presence of the virtual cluster is now always required. It is recommended to deploy the shoot-dns-service extension via the gardener-operator.
```
