### PR TITLE
Annotate extension resource to make usage of next-generation controller visible

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -183,6 +183,9 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 	if err := a.createOrUpdateSeedResources(exCtx, controllerModeNormal); err != nil {
 		return err
 	}
+	if err := a.updateExtensionAnnotation(exCtx); err != nil {
+		return err
+	}
 	return a.createOrUpdateDNSProviders(exCtx)
 }
 
@@ -528,6 +531,26 @@ func (a *actuator) ensureStateRefreshed(exCtx extensionContext) error {
 		return err
 	}
 	return handler.Update("refresh")
+}
+
+// updateExtensionAnnotation updates the annotation of the extension with the information if the next generation controller should be used or not.
+// This information is used by the shoot-cert-service to configure the correct dns class on creating DNSEntries for DNS challenges.
+func (a *actuator) updateExtensionAnnotation(exCtx extensionContext) error {
+	annotationState := exCtx.ex.Annotations[ShootDNSServiceUseNextGenerationController] == "true"
+	if exCtx.useNextGenerationController() == annotationState {
+		// nothing to do
+		return nil
+	}
+	patch := client.MergeFrom(exCtx.ex.DeepCopy())
+	if exCtx.useNextGenerationController() {
+		kutil.SetMetaDataAnnotation(exCtx.ex, ShootDNSServiceUseNextGenerationController, "true")
+	} else {
+		delete(exCtx.ex.Annotations, ShootDNSServiceUseNextGenerationController)
+	}
+	if err := a.client.Patch(exCtx.ctx, exCtx.ex, patch); err != nil {
+		return fmt.Errorf("failed to patch extension annotation: %w", err)
+	}
+	return nil
 }
 
 func (a *actuator) createOrUpdateDNSProviders(exCtx extensionContext) error {

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -961,6 +961,86 @@ func checkValues(values map[string]any, expectedYAML string) {
 	Expect(strings.TrimSpace(string(data))).To(Equal(strings.TrimSpace(expectedYAML)), "chart values do not match expected YAML")
 }
 
+var _ = Describe("actuator.updateExtensionAnnotation", func() {
+	var (
+		ctx        context.Context
+		seedClient client.Client
+		scheme     *runtime.Scheme
+		a          *actuator
+		ex         *extensionsv1alpha1.Extension
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+		seedClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		a = &actuator{client: seedClient}
+		ex = &extensionsv1alpha1.Extension{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot-dns-service",
+				Namespace: "shoot--foo--bar",
+			},
+		}
+	})
+
+	DescribeTable("update annotation",
+		func(initialAnnotations map[string]string, useNextGenerationController bool, expectedAnnotations map[string]string, expectPatch bool) {
+			ex.Annotations = initialAnnotations
+			Expect(seedClient.Create(ctx, ex)).To(Succeed())
+			originalResourceVersion := ex.ResourceVersion
+
+			exCtx := extensionContext{
+				ctx:       ctx,
+				log:       GinkgoLogr,
+				ex:        ex,
+				dnsconfig: &apisservice.DNSConfig{UseNextGenerationController: new(useNextGenerationController)},
+				globalConfig: config.DNSServiceConfig{
+					UseNextGenerationController: true,
+				},
+			}
+
+			Expect(a.updateExtensionAnnotation(exCtx)).To(Succeed())
+
+			Expect(ex.Annotations).To(Equal(expectedAnnotations))
+
+			updated := &extensionsv1alpha1.Extension{}
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(ex), updated)).To(Succeed())
+			Expect(updated.Annotations).To(Equal(expectedAnnotations))
+			if expectPatch {
+				Expect(updated.ResourceVersion).ToNot(Equal(originalResourceVersion), "expected patch to have been issued")
+			} else {
+				Expect(updated.ResourceVersion).To(Equal(originalResourceVersion), "expected no patch to have been issued")
+			}
+		},
+		Entry("add annotation when useNextGenerationController=true and annotation missing",
+			map[string]string{"existing": "value"},
+			true,
+			map[string]string{"existing": "value", ShootDNSServiceUseNextGenerationController: "true"},
+			true),
+		Entry("no-op when useNextGenerationController=true and annotation already 'true'",
+			map[string]string{ShootDNSServiceUseNextGenerationController: "true"},
+			true,
+			map[string]string{ShootDNSServiceUseNextGenerationController: "true"},
+			false),
+		Entry("remove annotation when useNextGenerationController=false and annotation is 'true'",
+			map[string]string{ShootDNSServiceUseNextGenerationController: "true", "existing": "value"},
+			false,
+			map[string]string{"existing": "value"},
+			true),
+		Entry("no-op when useNextGenerationController=false and annotation missing",
+			nil,
+			false,
+			nil,
+			false),
+		Entry("no-op when useNextGenerationController=false and annotation has non-'true' value",
+			map[string]string{ShootDNSServiceUseNextGenerationController: "other"},
+			false,
+			map[string]string{ShootDNSServiceUseNextGenerationController: "other"},
+			false),
+	)
+})
+
 var _ = Describe("extensionContext.useNextGenerationController", func() {
 	var (
 		exCtx extensionContext


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Annotate extension resource with  `service.dns.extensions.gardener.cloud/use-next-generation-controller` to make usage of next-generation controller visible for other components like shoot-cert-service.
As there are multiple switches, other components need a simple way to decide if next-generation is used instead of trying to reimplement the logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Annotate extension resource to make usage of next-generation controller visible
```
