### PR TITLE
[next-generation] Add dashboard for dns-controller-manager next-generation

### DIFF
--- a/charts/internal/shoot-dns-service-seed/files/shoot-dns-service-dashboard.json
+++ b/charts/internal/shoot-dns-service-seed/files/shoot-dns-service-dashboard.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1779368017107,
+  "iteration": 1781699823623,
   "links": [],
   "panels": [
     {
@@ -146,7 +146,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.47",
+      "pluginVersion": "7.5.49",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -267,7 +267,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.47",
+      "pluginVersion": "7.5.49",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -389,7 +389,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.47",
+      "pluginVersion": "7.5.49",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -489,7 +489,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.47",
+      "pluginVersion": "7.5.49",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -532,7 +532,7 @@
           "label": "requests/s",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -669,7 +669,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.47",
+      "pluginVersion": "7.5.49",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -735,7 +735,7 @@
           "label": "requests/s",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -893,7 +893,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
@@ -923,5 +923,5 @@
   "timezone": "browser",
   "title": "Shoot DNS Service Dashboard",
   "uid": "shoot-dns-service",
-  "version": 2
+  "version": 1
 }

--- a/charts/internal/shoot-dns-service-seed/files/shoot-dns-service-dashboard.json
+++ b/charts/internal/shoot-dns-service-seed/files/shoot-dns-service-dashboard.json
@@ -1,0 +1,927 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1779368017107,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "prometheus",
+      "description": "Current uptime status.",
+      "editable": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 1,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(sum(up{job=\"shoot-dns-service\"} == 1) / sum(up{job=\"shoot-dns-service\"})) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 600
+        }
+      ],
+      "thresholds": "50, 80",
+      "title": "UP Time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows the CPU usage and shows the requests and limits.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 4,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.47",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"shoot-dns-service-(.+)\"}[$__rate_interval])) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-current",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"shoot-dns-service-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-limits",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"shoot-dns-service-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-requests",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:147",
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:148",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows the memory usage.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.47",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(container_memory_working_set_bytes{pod=~\"shoot-dns-service-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-current",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"shoot-dns-service-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-limits",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"shoot-dns-service-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-requests",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:222",
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:223",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "The next-generation dns-controller-manager periodically lists all `DNSEntry` resources and aggregates them by hosted zone and reconciliation state. ",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 45,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.47",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(external_dns_management_dns_entries) by (providertype,zone,state)",
+          "interval": "",
+          "legendFormat": "{{providertype}}/{{zone}}/{{state}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DNS Entries",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:292",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:293",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Cumulative number of API calls made to a DNS provider, broken down by provider type, zone, and request type",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 49,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.47",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(external_dns_management_requests_per_zone[$__rate_interval])) by (providertype,zone,requesttype)",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{providertype}}/{{zone}}/{{requesttype}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Requests to DNS API Endpoints",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:731",
+          "format": "short",
+          "label": "requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:732",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "The lookup processor resolves hostnames referenced in `DNSEntry` resources (targets using DNS names instead of IP addresses) and queues re-reconciliations when results change.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 29
+              },
+              {
+                "color": "green",
+                "value": 31
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.47",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "external_dns_management_lookup_processor_jobs",
+          "interval": "",
+          "legendFormat": "jobs",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Lookup Processor Jobs",
+      "type": "timeseries"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Lookups for all lookup jobs.\n\"skips\" is the rate  of hostname lookups skipped because the processor was overloaded.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 56,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.47",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(external_dns_management_lookup_processor_lookups[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "lookups",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(external_dns_management_lookup_processor_skips[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "skips",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(external_dns_management_lookup_processor_errors[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "errors",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(external_dns_management_lookup_processor_lookup_changed[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "changes",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Lookups",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:295",
+          "format": "short",
+          "label": "requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:296",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGreens",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "The lookup processor resolves hostnames referenced in `DNSEntry` resources (targets using DNS names instead of IP addresses) and queues re-reconciliations when results change.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 57,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.47",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(external_dns_management_lookup_processor_seconds_bucket[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Lookup Latency",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "datasource": "vali",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 43,
+      "interval": "",
+      "options": {
+        "dedupStrategy": "none",
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "expr": "{pod_name=~\"shoot-dns-service-(.+)\"} |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "controlplane",
+    "seed",
+    "logging"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "3h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "14d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Shoot DNS Service Dashboard",
+  "uid": "shoot-dns-service",
+  "version": 2
+}

--- a/charts/internal/shoot-dns-service-seed/templates/0helpers.tpl
+++ b/charts/internal/shoot-dns-service-seed/templates/0helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "service.name" -}}
-{{- default .Chart.Name .Values.serviceName | trunc 63 | trimSuffix "-" -}}
+{{- default "shoot-dns-service" .Values.serviceName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/deployment.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ template "service.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "service.name" . }}
-    chart: {{ template "service.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     high-availability-config.resources.gardener.cloud/type: controller
 spec:
   revisionHistoryLimit: 2
@@ -28,6 +28,8 @@ spec:
       labels:
         app: {{ template "service.name" . }}
         release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "service.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-runtime-apiserver: allowed

--- a/charts/internal/shoot-dns-service-seed/templates/next-generation-config.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/next-generation-config.yaml
@@ -5,10 +5,8 @@ metadata:
   name: {{ template "service.name" . }}-next-generation-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "service.name" . }}
-    chart: {{ template "service.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   config: |
 {{- include "next-generation-config" . | indent 4 }}

--- a/charts/internal/shoot-dns-service-seed/templates/next-generation-dashboards-configmap.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/next-generation-dashboards-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.nextGeneration.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    dashboard.monitoring.gardener.cloud/shoot: "true"
+  name: {{ template "service.name" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
+data:
+  shoot-dns-service-dashboard.json: |-
+    {{- (.Files.Get "files/shoot-dns-service-dashboard.json") | nindent 6 }}
+{{- end }}

--- a/charts/internal/shoot-dns-service-seed/templates/next-generation-service.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/next-generation-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.nextGeneration.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":2753,"protocol":"TCP"}]'
+  name: {{ template "service.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 2753
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: ClusterIP
+{{- end }}

--- a/charts/internal/shoot-dns-service-seed/templates/next-generation-servicemonitor.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/next-generation-servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.nextGeneration.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    prometheus: shoot
+  name: {{ template "service.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - metricRelabelings:
+        - action: keep
+          regex: ^(external_dns_management_.+)$
+          sourceLabels:
+            - __name__
+      port: metrics
+      relabelings:
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "service.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/internal/shoot-dns-service-seed/templates/poddisruptionbudget.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/poddisruptionbudget.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "service.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "service.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/internal/shoot-dns-service-seed/templates/rbac.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/rbac.yaml
@@ -4,10 +4,8 @@ metadata:
   name: {{ template "service.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "service.name" . }}
-    chart: {{ template "service.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - "dns.gardener.cloud"

--- a/charts/internal/shoot-dns-service-seed/templates/serviceaccount.yaml
+++ b/charts/internal/shoot-dns-service-seed/templates/serviceaccount.yaml
@@ -4,8 +4,6 @@ metadata:
   name: {{ template "service.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "service.name" . }}
-    chart: {{ template "service.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 automountServiceAccountToken: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
The next-generation DNS controller manager running in the control plane now manages all DNS providers itself. The legacy controller delegated these tasks to the seed's DNS controller manager and it was not possible to restrict the metrics by shoot cluster, only per provider and zone.
Therefore we can now introduce a plutono dashboard with useful metrics per shoot cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] Add dashboard for dns-controller-manager next-generation
```
