### PR TITLE
Bump golang version in TestDefinition to 1.26

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -18,4 +18,4 @@ spec:
       --shoot-name=$SHOOT_NAME
       --existing-shoot-name=$SHOOT_NAME
       --project-namespace=$PROJECT_NAMESPACE
-  image: golang:1.25.1
+  image: golang:1.26.4


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-shoot-dns-service/pull/302.

Currently the test execution by TM fails with:
```
2026-07-03T12:29:55.275184748Z stderr F time="2026-07-03T12:29:55.274Z" level=info msg="capturing logs" argo=true
2026-07-03T12:29:55.299532128Z stderr F go: go.mod requires go >= 1.26.0 (running go 1.25.1; GOTOOLCHAIN=local)
2026-07-03T12:29:56.276409891Z stderr F time="2026-07-03T12:29:56.276Z" level=info msg="sub-process exited" argo=true error="<nil>"
2026-07-03T12:29:56.276446073Z stderr F time="2026-07-03T12:29:56.276Z" level=warning msg="cannot save artifact /tmp/tm/export" argo=true error="stat /tmp/tm/export: no such file or directory"
2026-07-03T12:29:56.27788057Z stderr F Error: exit status 1
```

This is because the go image version in the TestDefinition (go1.25) is not updated and not compatible with the minimum go version the module requires (go.mod -> go1.26).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the test execution to fail due to outdated go version in the TestDefinition is now fixed.
```

