### PR TITLE
Prevent `nil pointer dereference` in the TM test

### DIFF
--- a/.test-defs/shootdns-test.yaml
+++ b/.test-defs/shootdns-test.yaml
@@ -13,7 +13,7 @@ spec:
   args:
     - >-
       go test -timeout=0 ./test/system
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
       --shoot-name=$SHOOT_NAME
       --existing-shoot-name=$SHOOT_NAME

--- a/test/system/shootdns_test.go
+++ b/test/system/shootdns_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
@@ -53,7 +54,7 @@ func (f *shootDNSFramework) prepareClientsAndCluster(ctx context.Context) {
 	if err != nil {
 		Fail(fmt.Sprintf("get cluster failed: %s", err))
 	}
-	if !f.cluster.Shoot.Spec.Addons.NginxIngress.Enabled {
+	if !v1beta1helper.NginxIngressEnabled(f.cluster.Shoot.Spec.Addons) {
 		Fail("The test requires .spec.addons.nginxIngress.enabled to be true")
 	}
 	if f.cluster.Shoot.Spec.DNS == nil || f.cluster.Shoot.Spec.DNS.Domain == nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
When Shoot `.spec.addons=nil`, instead of failing with:
```
   [PANICKED] Test Panicked
   In [BeforeEach] at: /usr/local/go/src/runtime/panic.go:336 @ 08/12/26 06:38:10.908

   runtime error: invalid memory address or nil pointer dereference

   Full Stack Trace
     github.com/gardener/gardener-extension-shoot-dns-service/test/system_test.(*shootDNSFramework).prepareClientsAndCluster(0xa640a496b60, {0x330f168?, 0xa640ac1f8f0?})
     	/src/test/system/shootdns_test.go:56 +0x18c
```

the test now fails as expected with:
```
  [FAILED] The test requires .spec.addons.nginxIngress.enabled to be true
  In [BeforeEach] at: /go/src/github.com/gardener/gardener-extension-shoot-dns-service/test/system/shootdns_test.go:58 @ 08/12/26 14:57:29.9
```

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener-extension-shoot-dns-service/issues/804

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing the TM test to panic with `nil pointer dereference` when Shoot `.spec.addons=nil` (always the case for Shoots with Kubernetes 1.35+) is now prevented. The test execution now properly state that it requires nginx-ingress to be enabled.
```
